### PR TITLE
feat: CRUD responsavel (#10)

### DIFF
--- a/src/backend/src/controllers/ResponsavelController.ts
+++ b/src/backend/src/controllers/ResponsavelController.ts
@@ -1,10 +1,8 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import { ResponsavelService } from "../services/ResponsavelService";
 
 const service = new ResponsavelService();
 
-// TODO: este controller é apenas um exemplo com GET.
-// Ainda falta os demais métodos (create, update, delete).
 export const ResponsavelController = {
   async findAll(_req: Request, res: Response) {
     const items = await service.findAll();
@@ -15,5 +13,43 @@ export const ResponsavelController = {
     const item = await service.findById(Number(req.params.id));
     if (!item) return res.status(404).json({ error: "Não encontrado" });
     res.json(item);
+  },
+
+  async create(req: Request, res: Response, next: NextFunction) {
+    const { nome, email } = req.body;
+
+    if (!nome || nome.trim() === '') {
+      return res.status(400).json({ error: 'nome é obrigatório' });
+    }
+    if (!email || email.trim() === '') {
+      return res.status(400).json({ error: 'email é obrigatório' });
+    }
+
+    try {
+      const item = await service.create(req.body);
+      res.status(201).json(item);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const item = await service.update(Number(req.params.id), req.body);
+      if (!item) return res.status(404).json({ error: 'Não encontrado' });
+      res.json(item);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const deleted = await service.delete(Number(req.params.id));
+      if (!deleted) return res.status(404).json({ error: 'Não encontrado' });
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
   },
 };

--- a/src/backend/src/routes/responsavel.routes.ts
+++ b/src/backend/src/routes/responsavel.routes.ts
@@ -3,9 +3,10 @@ import { ResponsavelController } from "../controllers/ResponsavelController";
 
 const router = Router();
 
-// TODO: este arquivo é apenas um exemplo com GET.
-// Ainda falta as demais rotas (POST, PUT, DELETE)
 router.get("/", ResponsavelController.findAll);
 router.get("/:id", ResponsavelController.findById);
+router.post("/", ResponsavelController.create);
+router.put("/:id", ResponsavelController.update);
+router.delete("/:id", ResponsavelController.delete);
 
 export default router;

--- a/src/backend/tests/responsavel.test.ts
+++ b/src/backend/tests/responsavel.test.ts
@@ -1,0 +1,147 @@
+import request from 'supertest';
+import app from '../src/app';
+import { ResponsavelService } from '../src/services/ResponsavelService';
+
+jest.mock('../src/services/ResponsavelService');
+
+const MockedService = ResponsavelService as jest.MockedClass<typeof ResponsavelService>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /api/responsaveis', () => {
+  it('201 com body válido', async () => {
+    const created = { id: 1, nome: 'João', email: 'joao@test.com', cargo: null, departamento: null, telefone: null };
+    (MockedService.prototype.create as jest.Mock).mockResolvedValue(created);
+
+    const res = await request(app)
+      .post('/api/responsaveis')
+      .send({ nome: 'João', email: 'joao@test.com' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(created);
+  });
+
+  it('400 sem nome', async () => {
+    const res = await request(app)
+      .post('/api/responsaveis')
+      .send({ email: 'joao@test.com' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'nome é obrigatório' });
+  });
+
+  it('400 nome vazio', async () => {
+    const res = await request(app)
+      .post('/api/responsaveis')
+      .send({ nome: '', email: 'joao@test.com' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'nome é obrigatório' });
+  });
+
+  it('400 sem email', async () => {
+    const res = await request(app)
+      .post('/api/responsaveis')
+      .send({ nome: 'João' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'email é obrigatório' });
+  });
+
+  it('400 email vazio', async () => {
+    const res = await request(app)
+      .post('/api/responsaveis')
+      .send({ nome: 'João', email: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'email é obrigatório' });
+  });
+
+  it('400 sem nome e sem email', async () => {
+    const res = await request(app)
+      .post('/api/responsaveis')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'nome é obrigatório' });
+  });
+
+  it('500 quando service lança erro', async () => {
+    (MockedService.prototype.create as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app)
+      .post('/api/responsaveis')
+      .send({ nome: 'João', email: 'joao@test.com' });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Erro interno do servidor' });
+  });
+});
+
+describe('PUT /api/responsaveis/:id', () => {
+  const updated = { id: 1, nome: 'João Atualizado', email: 'joao@test.com', cargo: null, departamento: null, telefone: null };
+
+  it('200 com dados válidos', async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(updated);
+
+    const res = await request(app)
+      .put('/api/responsaveis/1')
+      .send({ nome: 'João Atualizado' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(updated);
+  });
+
+  it('404 quando id não existe', async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/responsaveis/999')
+      .send({ nome: 'João' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Não encontrado' });
+  });
+
+  it('500 quando service lança erro', async () => {
+    (MockedService.prototype.update as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app)
+      .put('/api/responsaveis/1')
+      .send({ nome: 'João' });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Erro interno do servidor' });
+  });
+});
+
+describe('DELETE /api/responsaveis/:id', () => {
+  it('204 quando removido com sucesso', async () => {
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(true);
+
+    const res = await request(app).delete('/api/responsaveis/1');
+
+    expect(res.status).toBe(204);
+    expect(res.body).toEqual({});
+  });
+
+  it('404 quando id não existe', async () => {
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(false);
+
+    const res = await request(app).delete('/api/responsaveis/999');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Não encontrado' });
+  });
+
+  it('500 quando service lança erro', async () => {
+    (MockedService.prototype.delete as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app).delete('/api/responsaveis/1');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Erro interno do servidor' });
+  });
+});


### PR DESCRIPTION
## O que mudou
- Implementado CRUD completo de responsáveis: `create`, `update`, `delete` no controller (só `findAll` e `findById` existiam)
- Adicionadas rotas `POST /`, `PUT /:id`, `DELETE /:id` em `responsavel.routes.ts`
- Criado arquivo de testes `responsavel.test.ts` com 13 casos cobrindo POST, PUT e DELETE

## Por quê
O controller e as rotas de responsáveis eram apenas um esqueleto de exemplo com GET. O CRUD precisava estar completo para permitir gerenciamento real de responsáveis via API.

## Como testar
```bash
# Testes automatizados
cd src/backend && npx jest tests/responsavel.test.ts

# Manual — Criar
curl -X POST http://localhost:3000/api/responsaveis \
  -H "Content-Type: application/json" \
  -d '{"nome":"João","email":"joao@test.com"}'

# Manual — Atualizar
curl -X PUT http://localhost:3000/api/responsaveis/1 \
  -H "Content-Type: application/json" \
  -d '{"nome":"João Atualizado"}'

# Manual — Remover (esperado: 204 sem body)
curl -X DELETE http://localhost:3000/api/responsaveis/1
```

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
- [Risco] `PUT` não valida campos do body — campos desconhecidos são silenciosamente ignorados pelo Sequelize, sem erro explícito ao cliente.
- [Manutenção] `BaseRepository.update` executa 2 queries (findById + update). Aceitável agora; candidato a otimização com `Model.update({ returning: true })` se volume crescer.
- [Teste] Testes mocam o service — não exercitam banco real. Testes de integração contra banco ficam pendentes como próximo passo.
