### PR TITLE
feat: CRUD ambientes (#9)

### DIFF
--- a/src/backend/src/controllers/AmbienteController.ts
+++ b/src/backend/src/controllers/AmbienteController.ts
@@ -1,0 +1,52 @@
+import { NextFunction, Request, Response } from "express";
+import { AmbienteService } from "../services/AmbienteService";
+
+const service = new AmbienteService();
+
+export const AmbienteController = {
+  async findAll(_req: Request, res: Response) {
+    const items = await service.findAll();
+    res.json(items);
+  },
+
+  async findById(req: Request, res: Response) {
+    const item = await service.findById(Number(req.params.id));
+    if (!item) return res.status(404).json({ error: "Não encontrado" });
+    res.json(item);
+  },
+
+  async create(req: Request, res: Response, next: NextFunction) {
+    const { nome } = req.body;
+
+    if (!nome || nome.trim() === '') {
+      return res.status(400).json({ error: 'nome é obrigatório' });
+    }
+
+    try {
+      const item = await service.create(req.body);
+      res.status(201).json(item);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const item = await service.update(Number(req.params.id), req.body);
+      if (!item) return res.status(404).json({ error: 'Não encontrado' });
+      res.json(item);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const deleted = await service.delete(Number(req.params.id));
+      if (!deleted) return res.status(404).json({ error: 'Não encontrado' });
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/src/backend/src/repositories/AmbienteRepository.ts
+++ b/src/backend/src/repositories/AmbienteRepository.ts
@@ -1,0 +1,8 @@
+import { Ambiente } from '../models/Ambiente';
+import { BaseRepository } from './BaseRepository';
+
+export class AmbienteRepository extends BaseRepository<Ambiente> {
+  constructor() {
+    super(Ambiente);
+  }
+}

--- a/src/backend/src/routes/ambiente.routes.ts
+++ b/src/backend/src/routes/ambiente.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { AmbienteController } from "../controllers/AmbienteController";
+
+const router = Router();
+
+router.get("/", AmbienteController.findAll);
+router.get("/:id", AmbienteController.findById);
+router.post("/", AmbienteController.create);
+router.put("/:id", AmbienteController.update);
+router.delete("/:id", AmbienteController.delete);
+
+export default router;

--- a/src/backend/src/routes/index.ts
+++ b/src/backend/src/routes/index.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
+import ambienteRoutes from './ambiente.routes';
 import responsavelRoutes from './responsavel.routes';
 
 const router = Router();
 
+router.use('/ambientes', ambienteRoutes);
 router.use('/responsaveis', responsavelRoutes);
 
 export default router;

--- a/src/backend/src/services/AmbienteService.ts
+++ b/src/backend/src/services/AmbienteService.ts
@@ -1,0 +1,27 @@
+import { CreationAttributes } from 'sequelize';
+import { Ambiente } from '../models/Ambiente';
+import { AmbienteRepository } from '../repositories/AmbienteRepository';
+
+export class AmbienteService {
+  private repo = new AmbienteRepository();
+
+  findAll() {
+    return this.repo.findAll();
+  }
+
+  findById(id: number) {
+    return this.repo.findById(id);
+  }
+
+  create(data: CreationAttributes<Ambiente>) {
+    return this.repo.create(data);
+  }
+
+  update(id: number, data: Partial<CreationAttributes<Ambiente>>) {
+    return this.repo.update(id, data);
+  }
+
+  delete(id: number) {
+    return this.repo.delete(id);
+  }
+}

--- a/src/backend/tests/ambiente.test.ts
+++ b/src/backend/tests/ambiente.test.ts
@@ -1,0 +1,153 @@
+import request from 'supertest';
+import app from '../src/app';
+import { AmbienteService } from '../src/services/AmbienteService';
+
+jest.mock('../src/services/AmbienteService');
+
+const MockedService = AmbienteService as jest.MockedClass<typeof AmbienteService>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/ambientes', () => {
+  it('200 com lista de ambientes', async () => {
+    const list = [{ id: 1, nome: 'Lab 1', bloco: 'A', andar: '1', responsavel_id: null }];
+    (MockedService.prototype.findAll as jest.Mock).mockResolvedValue(list);
+
+    const res = await request(app).get('/api/ambientes');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(list);
+  });
+});
+
+describe('GET /api/ambientes/:id', () => {
+  it('200 quando encontrado', async () => {
+    const item = { id: 1, nome: 'Lab 1', bloco: 'A', andar: '1', responsavel_id: null };
+    (MockedService.prototype.findById as jest.Mock).mockResolvedValue(item);
+
+    const res = await request(app).get('/api/ambientes/1');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(item);
+  });
+
+  it('404 quando não encontrado', async () => {
+    (MockedService.prototype.findById as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app).get('/api/ambientes/999');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Não encontrado' });
+  });
+});
+
+describe('POST /api/ambientes', () => {
+  it('201 com body válido', async () => {
+    const created = { id: 1, nome: 'Lab 1', bloco: 'A', andar: '1', responsavel_id: null };
+    (MockedService.prototype.create as jest.Mock).mockResolvedValue(created);
+
+    const res = await request(app)
+      .post('/api/ambientes')
+      .send({ nome: 'Lab 1', bloco: 'A', andar: '1' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(created);
+  });
+
+  it('400 sem nome', async () => {
+    const res = await request(app)
+      .post('/api/ambientes')
+      .send({ bloco: 'A' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'nome é obrigatório' });
+  });
+
+  it('400 nome vazio', async () => {
+    const res = await request(app)
+      .post('/api/ambientes')
+      .send({ nome: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'nome é obrigatório' });
+  });
+
+  it('500 quando service lança erro', async () => {
+    (MockedService.prototype.create as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app)
+      .post('/api/ambientes')
+      .send({ nome: 'Lab 1' });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Erro interno do servidor' });
+  });
+});
+
+describe('PUT /api/ambientes/:id', () => {
+  const updated = { id: 1, nome: 'Lab Atualizado', bloco: 'B', andar: '2', responsavel_id: null };
+
+  it('200 com dados válidos', async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(updated);
+
+    const res = await request(app)
+      .put('/api/ambientes/1')
+      .send({ nome: 'Lab Atualizado' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(updated);
+  });
+
+  it('404 quando id não existe', async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/ambientes/999')
+      .send({ nome: 'Lab' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Não encontrado' });
+  });
+
+  it('500 quando service lança erro', async () => {
+    (MockedService.prototype.update as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app)
+      .put('/api/ambientes/1')
+      .send({ nome: 'Lab' });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Erro interno do servidor' });
+  });
+});
+
+describe('DELETE /api/ambientes/:id', () => {
+  it('204 quando removido com sucesso', async () => {
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(true);
+
+    const res = await request(app).delete('/api/ambientes/1');
+
+    expect(res.status).toBe(204);
+    expect(res.body).toEqual({});
+  });
+
+  it('404 quando id não existe', async () => {
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(false);
+
+    const res = await request(app).delete('/api/ambientes/999');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Não encontrado' });
+  });
+
+  it('500 quando service lança erro', async () => {
+    (MockedService.prototype.delete as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app).delete('/api/ambientes/1');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Erro interno do servidor' });
+  });
+});


### PR DESCRIPTION
## O que mudou
- Criados `AmbienteRepository`, `AmbienteService` e `AmbienteController` com CRUD completo
- Adicionadas rotas `GET /`, `GET /:id`, `POST /`, `PUT /:id`, `DELETE /:id` em `ambiente.routes.ts`
- Registrada rota `/api/ambientes` em `routes/index.ts`
- Criado `ambiente.test.ts` com 13 casos cobrindo todos os endpoints

## Por quê
Não existia nenhuma camada de API para ambientes — apenas o model do banco. O CRUD permite gerenciar ambientes via API seguindo o mesmo padrão já estabelecido em responsáveis.

## Como testar
```bash
# Testes automatizados
cd src/backend && npx jest tests/ambiente.test.ts

# Manual — Listar
curl http://localhost:3000/api/ambientes

# Manual — Criar
curl -X POST http://localhost:3000/api/ambientes \
  -H "Content-Type: application/json" \
  -d '{"nome":"Lab 1","bloco":"A","andar":"1"}'

# Manual — Atualizar
curl -X PUT http://localhost:3000/api/ambientes/1 \
  -H "Content-Type: application/json" \
  -d '{"bloco":"B"}'

# Manual — Remover (esperado: 204 sem body)
curl -X DELETE http://localhost:3000/api/ambientes/1
```

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
- [Risco] `responsavel_id` em `POST`/`PUT` não é validado — body pode referenciar id inexistente sem retornar erro (FK não está configurada como constraint no Sequelize).
- [Manutenção] Estrutura idêntica à de responsáveis — se o padrão mudar (ex.: paginação, validação centralizada), ambos precisarão ser atualizados juntos. Candidato a extração futura.
- [Teste] Testes mocam o service inteiro — comportamento real do banco (constraint de `nome NOT NULL`, FK de `responsavel_id`) não é exercitado. Testes de integração ficam pendentes.
