### PR TITLE
feature/crudTipoMateriais

### DIFF
--- a/src/backend/src/controllers/TipoMaterialController.ts
+++ b/src/backend/src/controllers/TipoMaterialController.ts
@@ -1,0 +1,71 @@
+import { NextFunction, Request, Response } from "express";
+import { ForeignKeyConstraintError, UniqueConstraintError } from "sequelize";
+import { TipoMaterialService } from "../services/TipoMaterialService";
+
+const service = new TipoMaterialService();
+
+export const TipoMaterialController = {
+  async findAll(_req: Request, res: Response) {
+    const items = await service.findAll();
+    res.json(items);
+  },
+
+  async findById(req: Request, res: Response) {
+    const item = await service.findById(Number(req.params.id));
+    if (!item) return res.status(404).json({ error: "Não encontrado" });
+    res.json(item);
+  },
+
+  async create(req: Request, res: Response, next: NextFunction) {
+    const { nome } = req.body;
+
+    if (!nome || nome.trim() === "") {
+      return res.status(400).json({ error: "nome é obrigatório" });
+    }
+
+    try {
+      const item = await service.create(req.body);
+      res.status(201).json(item);
+    } catch (err) {
+      if (err instanceof UniqueConstraintError) {
+        return res
+          .status(409)
+          .json({ error: "Já existe um tipo de material com esses dados" });
+      }
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const item = await service.update(Number(req.params.id), req.body);
+      if (!item) return res.status(404).json({ error: "Não encontrado" });
+      res.json(item);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const id = Number(req.params.id);
+      const vinculados = await service.findPatrimoniosVinculados(id);
+      if (vinculados.length > 0) {
+        return res.status(409).json({
+          error:
+            "Tipo de material possui patrimônios vinculados e não pode ser excluído. Reatribua os patrimônios antes de excluir.",
+          patrimonios: vinculados.map((p) => ({
+            id: p.id,
+            numero_patrimonio: p.numero_patrimonio,
+            descricao: p.descricao,
+          })),
+        });
+      }
+      const deleted = await service.delete(id);
+      if (!deleted) return res.status(404).json({ error: "Não encontrado" });
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/src/backend/src/repositories/TipoMaterialRepository.ts
+++ b/src/backend/src/repositories/TipoMaterialRepository.ts
@@ -1,0 +1,8 @@
+import { TipoMaterial } from "../models/TipoMaterial";
+import { BaseRepository } from "./BaseRepository";
+
+export class TipoMaterialRepository extends BaseRepository<TipoMaterial> {
+  constructor() {
+    super(TipoMaterial);
+  }
+}

--- a/src/backend/src/routes/index.ts
+++ b/src/backend/src/routes/index.ts
@@ -1,10 +1,12 @@
-import { Router } from 'express';
-import ambienteRoutes from './ambiente.routes';
-import responsavelRoutes from './responsavel.routes';
+import { Router } from "express";
+import ambienteRoutes from "./ambiente.routes";
+import responsavelRoutes from "./responsavel.routes";
+import tipoMaterialRoutes from "./tipoMaterial.routes";
 
 const router = Router();
 
-router.use('/ambientes', ambienteRoutes);
-router.use('/responsaveis', responsavelRoutes);
+router.use("/ambientes", ambienteRoutes);
+router.use("/responsaveis", responsavelRoutes);
+router.use("/tipo-material", tipoMaterialRoutes);
 
 export default router;

--- a/src/backend/src/routes/tipoMaterial.routes.ts
+++ b/src/backend/src/routes/tipoMaterial.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { TipoMaterialController } from "../controllers/TipoMaterialController";
+
+const router = Router();
+
+router.get("/", TipoMaterialController.findAll);
+router.get("/:id", TipoMaterialController.findById);
+router.post("/", TipoMaterialController.create);
+router.put("/:id", TipoMaterialController.update);
+router.delete("/:id", TipoMaterialController.delete);
+
+export default router;

--- a/src/backend/src/services/TipoMaterialService.ts
+++ b/src/backend/src/services/TipoMaterialService.ts
@@ -1,0 +1,35 @@
+import { CreationAttributes } from "sequelize";
+import { Patrimonio } from "../models/Patrimonio";
+import { TipoMaterial } from "../models/TipoMaterial";
+import { TipoMaterialRepository } from "../repositories/TipoMaterialRepository";
+
+export class TipoMaterialService {
+  private repo = new TipoMaterialRepository();
+
+  findAll() {
+    return this.repo.findAll();
+  }
+
+  findById(id: number) {
+    return this.repo.findById(id);
+  }
+
+  create(data: CreationAttributes<TipoMaterial>) {
+    return this.repo.create(data);
+  }
+
+  update(id: number, data: Partial<CreationAttributes<TipoMaterial>>) {
+    return this.repo.update(id, data);
+  }
+
+  async findPatrimoniosVinculados(id: number) {
+    return Patrimonio.findAll({
+      where: { tipo_material_id: id },
+      attributes: ["id", "numero_patrimonio", "descricao"],
+    });
+  }
+
+  delete(id: number) {
+    return this.repo.delete(id);
+  }
+}

--- a/src/backend/tests/tipo-material.test.ts
+++ b/src/backend/tests/tipo-material.test.ts
@@ -1,0 +1,173 @@
+import request from "supertest";
+import app from "../src/app";
+import { TipoMaterialService } from "../src/services/TipoMaterialService";
+
+jest.mock("../src/services/TipoMaterialService");
+
+const MockedService = TipoMaterialService as jest.MockedClass<typeof TipoMaterialService>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("GET /api/tipo-material", () => {
+  it("200 com lista de tipos de material", async () => {
+    const list = [{ id: 1, nome: "Eletrônico" }];
+    (MockedService.prototype.findAll as jest.Mock).mockResolvedValue(list);
+
+    const res = await request(app).get("/api/tipo-material");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(list);
+  });
+});
+
+describe("GET /api/tipo-material/:id", () => {
+  it("200 quando encontrado", async () => {
+    const item = { id: 1, nome: "Eletrônico" };
+    (MockedService.prototype.findById as jest.Mock).mockResolvedValue(item);
+
+    const res = await request(app).get("/api/tipo-material/1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(item);
+  });
+
+  it("404 quando não encontrado", async () => {
+    (MockedService.prototype.findById as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app).get("/api/tipo-material/999");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Não encontrado" });
+  });
+});
+
+describe("POST /api/tipo-material", () => {
+  it("201 com body válido", async () => {
+    const created = { id: 1, nome: "Eletrônico" };
+    (MockedService.prototype.create as jest.Mock).mockResolvedValue(created);
+
+    const res = await request(app)
+      .post("/api/tipo-material")
+      .send({ nome: "Eletrônico" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(created);
+  });
+
+  it("400 sem nome", async () => {
+    const res = await request(app).post("/api/tipo-material").send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "nome é obrigatório" });
+  });
+
+  it("400 nome vazio", async () => {
+    const res = await request(app)
+      .post("/api/tipo-material")
+      .send({ nome: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "nome é obrigatório" });
+  });
+
+  it("500 quando service lança erro", async () => {
+    (MockedService.prototype.create as jest.Mock).mockRejectedValue(new Error("DB error"));
+
+    const res = await request(app)
+      .post("/api/tipo-material")
+      .send({ nome: "Eletrônico" });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Erro interno do servidor" });
+  });
+});
+
+describe("PUT /api/tipo-material/:id", () => {
+  const updated = { id: 1, nome: "Mobiliário" };
+
+  it("200 com dados válidos", async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(updated);
+
+    const res = await request(app)
+      .put("/api/tipo-material/1")
+      .send({ nome: "Mobiliário" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(updated);
+  });
+
+  it("404 quando id não existe", async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app)
+      .put("/api/tipo-material/999")
+      .send({ nome: "Mobiliário" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Não encontrado" });
+  });
+
+  it("500 quando service lança erro", async () => {
+    (MockedService.prototype.update as jest.Mock).mockRejectedValue(new Error("DB error"));
+
+    const res = await request(app)
+      .put("/api/tipo-material/1")
+      .send({ nome: "Mobiliário" });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Erro interno do servidor" });
+  });
+});
+
+describe("DELETE /api/tipo-material/:id", () => {
+  it("204 quando removido sem vínculos", async () => {
+    (MockedService.prototype.findPatrimoniosVinculados as jest.Mock).mockResolvedValue([]);
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(true);
+
+    const res = await request(app).delete("/api/tipo-material/1");
+
+    expect(res.status).toBe(204);
+    expect(res.body).toEqual({});
+  });
+
+  it("404 quando id não existe", async () => {
+    (MockedService.prototype.findPatrimoniosVinculados as jest.Mock).mockResolvedValue([]);
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(false);
+
+    const res = await request(app).delete("/api/tipo-material/999");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Não encontrado" });
+  });
+
+  it("409 quando possui patrimônios vinculados", async () => {
+    const patrimonios = [
+      { id: 1, numero_patrimonio: "2024/001", descricao: "Computador Dell" },
+      { id: 2, numero_patrimonio: "2024/002", descricao: "Monitor LG" },
+    ];
+    (MockedService.prototype.findPatrimoniosVinculados as jest.Mock).mockResolvedValue(patrimonios);
+
+    const res = await request(app).delete("/api/tipo-material/1");
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/patrimônios vinculados/);
+    expect(res.body.patrimonios).toHaveLength(2);
+    expect(res.body.patrimonios[0]).toMatchObject({
+      numero_patrimonio: "2024/001",
+      descricao: "Computador Dell",
+    });
+  });
+
+  it("500 quando service lança erro", async () => {
+    (MockedService.prototype.findPatrimoniosVinculados as jest.Mock).mockRejectedValue(
+      new Error("DB error")
+    );
+
+    const res = await request(app).delete("/api/tipo-material/1");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Erro interno do servidor" });
+  });
+});

--- a/src/front/app/components/AmbienteForm.tsx
+++ b/src/front/app/components/AmbienteForm.tsx
@@ -1,9 +1,9 @@
-'use client'
+"use client";
 
-import { ArrowLeft, Save } from 'lucide-react';
-import Link from 'next/link';
-import { useParams, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { ArrowLeft, Save } from "lucide-react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
 const API = process.env.NEXT_PUBLIC_API_URL;
 
@@ -14,17 +14,17 @@ export default function AmbienteForm() {
   const router = useRouter();
   const isEdit = !!id;
 
-  const [nome, setNome] = useState('');
-  const [bloco, setBloco] = useState('');
-  const [andar, setAndar] = useState('');
-  const [responsavelId, setResponsavelId] = useState('');
+  const [nome, setNome] = useState("");
+  const [bloco, setBloco] = useState("");
+  const [andar, setAndar] = useState("");
+  const [responsavelId, setResponsavelId] = useState("");
   const [responsaveis, setResponsaveis] = useState<Responsavel[]>([]);
   const [loading, setLoading] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
 
   useEffect(() => {
     fetch(`${API}/responsaveis`)
-      .then(r => r.json())
+      .then((r) => r.json())
       .then(setResponsaveis)
       .catch(() => {});
   }, []);
@@ -32,14 +32,16 @@ export default function AmbienteForm() {
   useEffect(() => {
     if (!isEdit) return;
     fetch(`${API}/ambientes/${id}`)
-      .then(r => r.json())
-      .then(data => {
-        setNome(data.nome ?? '');
-        setBloco(data.bloco ?? '');
-        setAndar(data.andar ?? '');
-        setResponsavelId(data.responsavel_id ? String(data.responsavel_id) : '');
+      .then((r) => r.json())
+      .then((data) => {
+        setNome(data.nome ?? "");
+        setBloco(data.bloco ?? "");
+        setAndar(data.andar ?? "");
+        setResponsavelId(
+          data.responsavel_id ? String(data.responsavel_id) : "",
+        );
       })
-      .catch(() => setErro('Erro ao carregar ambiente'));
+      .catch(() => setErro("Erro ao carregar ambiente"));
   }, [id, isEdit]);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -47,7 +49,7 @@ export default function AmbienteForm() {
     setErro(null);
 
     if (!nome.trim()) {
-      setErro('Nome é obrigatório');
+      setErro("Nome é obrigatório");
       return;
     }
 
@@ -61,19 +63,19 @@ export default function AmbienteForm() {
 
     try {
       const url = isEdit ? `${API}/ambientes/${id}` : `${API}/ambientes`;
-      const method = isEdit ? 'PUT' : 'POST';
+      const method = isEdit ? "PUT" : "POST";
       const res = await fetch(url, {
         method,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.error ?? 'Erro ao salvar');
+        throw new Error(data.error ?? "Erro ao salvar");
       }
-      router.push('/ambientes');
+      router.push("/ambientes");
     } catch (err: unknown) {
-      setErro(err instanceof Error ? err.message : 'Erro ao salvar');
+      setErro(err instanceof Error ? err.message : "Erro ao salvar");
     } finally {
       setLoading(false);
     }
@@ -87,7 +89,7 @@ export default function AmbienteForm() {
         </Link>
         <div>
           <h1 className="text-2xl font-bold text-gray-900">
-            {isEdit ? 'Editar Ambiente' : 'Novo Ambiente'}
+            {isEdit ? "Editar Ambiente" : "Novo Ambiente"}
           </h1>
           <p className="text-gray-600">Preencha os dados do ambiente</p>
         </div>
@@ -97,7 +99,9 @@ export default function AmbienteForm() {
         {erro && <p className="text-red-600 mb-4">{erro}</p>}
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Informações Básicas</h2>
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              Informações Básicas
+            </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -108,7 +112,7 @@ export default function AmbienteForm() {
                   placeholder="Ex: Sala 201"
                   className="w-full px-4 py-2 border border-gray-300 rounded-lg"
                   value={nome}
-                  onChange={e => setNome(e.target.value)}
+                  onChange={(e) => setNome(e.target.value)}
                   required
                 />
               </div>
@@ -121,7 +125,7 @@ export default function AmbienteForm() {
                   placeholder="Ex: Bloco A"
                   className="w-full px-4 py-2 border border-gray-300 rounded-lg"
                   value={bloco}
-                  onChange={e => setBloco(e.target.value)}
+                  onChange={(e) => setBloco(e.target.value)}
                 />
               </div>
               <div>
@@ -133,14 +137,16 @@ export default function AmbienteForm() {
                   placeholder="Ex: 2º Andar"
                   className="w-full px-4 py-2 border border-gray-300 rounded-lg"
                   value={andar}
-                  onChange={e => setAndar(e.target.value)}
+                  onChange={(e) => setAndar(e.target.value)}
                 />
               </div>
             </div>
           </div>
 
           <div>
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Responsável</h2>
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              Responsável
+            </h2>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
                 Responsável pelo Ambiente
@@ -148,11 +154,13 @@ export default function AmbienteForm() {
               <select
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg"
                 value={responsavelId}
-                onChange={e => setResponsavelId(e.target.value)}
+                onChange={(e) => setResponsavelId(e.target.value)}
               >
                 <option value="">Selecione...</option>
-                {responsaveis.map(r => (
-                  <option key={r.id} value={r.id}>{r.nome}</option>
+                {responsaveis.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.nome}
+                  </option>
                 ))}
               </select>
             </div>
@@ -165,7 +173,11 @@ export default function AmbienteForm() {
               className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
             >
               <Save size={20} />
-              {loading ? 'Salvando...' : isEdit ? 'Salvar Alterações' : 'Cadastrar Ambiente'}
+              {loading
+                ? "Salvando..."
+                : isEdit
+                  ? "Salvar Alterações"
+                  : "Cadastrar Ambiente"}
             </button>
             <Link
               href="/ambientes"

--- a/src/front/app/components/SidebarLayout.tsx
+++ b/src/front/app/components/SidebarLayout.tsx
@@ -1,37 +1,59 @@
-'use client'
+"use client";
 
-import { useState } from 'react';
-import { usePathname } from 'next/navigation';
-import Link from 'next/link';
-import { Home, Package, MapPin, Users, UserCheck, Store, Tags, AlertCircle, Menu, X } from 'lucide-react';
+import { useState } from "react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import {
+  Home,
+  Package,
+  MapPin,
+  Users,
+  UserCheck,
+  Store,
+  Tags,
+  AlertCircle,
+  Menu,
+  X,
+} from "lucide-react";
 
 const menuItems = [
-  { path: '/', icon: Home, label: 'Dashboard' },
-  { path: '/patrimonios', icon: Package, label: 'Patrimônios' },
-  { path: '/ambientes', icon: MapPin, label: 'Ambientes' },
-  { path: '/responsaveis', icon: Users, label: 'Responsáveis' },
-  { path: '/conferentes', icon: UserCheck, label: 'Conferentes' },
-  { path: '/fornecedores', icon: Store, label: 'Fornecedores' },
-  { path: '/tipos-material', icon: Tags, label: 'Tipos de Material' },
-  { path: '/estados-item', icon: AlertCircle, label: 'Estados do Item' },
+  { path: "/", icon: Home, label: "Dashboard" },
+  { path: "/patrimonios", icon: Package, label: "Patrimônios" },
+  { path: "/ambientes", icon: MapPin, label: "Ambientes" },
+  { path: "/responsaveis", icon: Users, label: "Responsáveis" },
+  { path: "/conferentes", icon: UserCheck, label: "Conferentes" },
+  { path: "/fornecedores", icon: Store, label: "Fornecedores" },
+  { path: "/tipos-material", icon: Tags, label: "Tipos de Material" },
+  { path: "/estados-item", icon: AlertCircle, label: "Estados do Item" },
 ];
 
 const implementedRoutes: string[] = [
-  '/ambientes',
-  '/responsaveis',
+  "/ambientes",
+  "/responsaveis",
+  "/tipos-material",
 ];
 
-export default function SidebarLayout({ children }: { children: React.ReactNode }) {
+export default function SidebarLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [showBanner, setShowBanner] = useState(true);
   const pathname = usePathname();
-  const isPrototype = !implementedRoutes.some((prefix) => pathname === prefix || pathname.startsWith(prefix + '/'));
+  const isPrototype = !implementedRoutes.some(
+    (prefix) => pathname === prefix || pathname.startsWith(prefix + "/"),
+  );
 
   return (
     <div className="flex h-screen bg-gray-50">
-      <div className={`${sidebarOpen ? 'w-64' : 'w-0'} transition-all duration-300 bg-white border-r border-gray-200 overflow-hidden`}>
+      <div
+        className={`${sidebarOpen ? "w-64" : "w-0"} transition-all duration-300 bg-white border-r border-gray-200 overflow-hidden`}
+      >
         <div className="p-4 border-b border-gray-200">
-          <h1 className="text-xl font-bold text-gray-800">Gestão Patrimonial</h1>
+          <h1 className="text-xl font-bold text-gray-800">
+            Gestão Patrimonial
+          </h1>
         </div>
         <nav className="p-4">
           {menuItems.map((item) => {
@@ -43,8 +65,8 @@ export default function SidebarLayout({ children }: { children: React.ReactNode 
                 href={item.path}
                 className={`flex items-center gap-3 px-4 py-3 mb-2 rounded-lg transition-colors ${
                   isActive
-                    ? 'bg-blue-50 text-blue-600'
-                    : 'text-gray-700 hover:bg-gray-100'
+                    ? "bg-blue-50 text-blue-600"
+                    : "text-gray-700 hover:bg-gray-100"
                 }`}
               >
                 <Icon size={20} />
@@ -64,7 +86,9 @@ export default function SidebarLayout({ children }: { children: React.ReactNode 
             {sidebarOpen ? <X size={20} /> : <Menu size={20} />}
           </button>
           <div className="flex-1">
-            <h2 className="text-lg font-semibold text-gray-800">Sistema de Gestão Patrimonial - MVP</h2>
+            <h2 className="text-lg font-semibold text-gray-800">
+              Sistema de Gestão Patrimonial - MVP
+            </h2>
           </div>
         </header>
 
@@ -72,7 +96,10 @@ export default function SidebarLayout({ children }: { children: React.ReactNode 
           <div className="bg-amber-50 border-b border-amber-200 px-6 py-3 flex items-center justify-between gap-4">
             <div className="flex items-center gap-2 text-amber-800 text-sm">
               <span className="font-semibold">⚠ Protótipo</span>
-              <span>Esta aplicação está em desenvolvimento. As funcionalidades desta página ainda não foram implementadas.</span>
+              <span>
+                Esta aplicação está em desenvolvimento. As funcionalidades desta
+                página ainda não foram implementadas.
+              </span>
             </div>
             <button
               onClick={() => setShowBanner(false)}
@@ -82,9 +109,7 @@ export default function SidebarLayout({ children }: { children: React.ReactNode 
             </button>
           </div>
         )}
-        <main className="flex-1 overflow-auto p-6">
-          {children}
-        </main>
+        <main className="flex-1 overflow-auto p-6">{children}</main>
       </div>
     </div>
   );

--- a/src/front/app/components/TipoMaterialForm.tsx
+++ b/src/front/app/components/TipoMaterialForm.tsx
@@ -1,47 +1,141 @@
-'use client'
+"use client";
 
-import { ArrowLeft, Save } from 'lucide-react';
-import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { ArrowLeft, Save } from "lucide-react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const API = process.env.NEXT_PUBLIC_API_URL;
 
 export default function TipoMaterialForm() {
   const { id } = useParams();
   const isEdit = !!id;
+  const router = useRouter();
+
+  const [nome, setNome] = useState("");
+  const [descricao, setDescricao] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isEdit) return;
+
+    fetch(`${API}/tipo-material/${id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        setNome(data.nome ?? "");
+        setDescricao(data.descricao ?? "");
+      })
+      .catch((err) => setErro(err.message));
+  }, [id, isEdit]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErro(null);
+
+    if (!nome.trim()) {
+      setErro("Nome é obrigatório");
+      return;
+    }
+
+    setLoading(true);
+
+    const body = {
+      nome: nome.trim(),
+      descricao: descricao.trim() || null,
+    };
+
+    try {
+      const url = isEdit
+        ? `${API}/tipo-material/${id}`
+        : `${API}/tipo-material`;
+
+      const method = isEdit ? "PUT" : "POST";
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? "Erro ao salvar");
+      }
+
+      router.push("/tipos-material");
+    } catch (err: unknown) {
+      setErro(err instanceof Error ? err.message : "Erro ao salvar");
+    } finally {
+      setLoading(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-4">
-        <Link href="/tipos-material" className="p-2 hover:bg-gray-100 rounded-lg">
+        <Link
+          href="/tipos-material"
+          className="p-2 hover:bg-gray-100 rounded-lg"
+        >
           <ArrowLeft size={20} />
         </Link>
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{isEdit ? 'Editar Tipo de Material' : 'Novo Tipo de Material'}</h1>
+          <h1 className="text-2xl font-bold text-gray-900">
+            {isEdit ? "Editar Tipo de Material" : "Novo Tipo de Material"}
+          </h1>
           <p className="text-gray-600">Preencha os dados do tipo de material</p>
         </div>
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <form className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-6">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Informações do Tipo</h2>
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              Informações do Tipo
+            </h2>
             <div className="grid grid-cols-1 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Nome do Tipo *</label>
-                <input type="text" placeholder="Ex: Informática" className="w-full px-4 py-2 border border-gray-300 rounded-lg" />
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Nome do Tipo *
+                </label>
+                <input
+                  type="text"
+                  value={nome}
+                  onChange={(e) => setNome(e.target.value)}
+                  placeholder="Ex: Informática"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Descrição</label>
-                <textarea rows={3} placeholder="Descrição do tipo de material..." className="w-full px-4 py-2 border border-gray-300 rounded-lg"></textarea>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Descrição
+                </label>
+                <textarea
+                  rows={3}
+                  value={descricao}
+                  onChange={(e) => setDescricao(e.target.value)}
+                  placeholder="Descrição do tipo de material..."
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                ></textarea>
               </div>
             </div>
           </div>
 
           <div className="flex gap-4 pt-4 border-t border-gray-200">
-            <button type="submit" className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+            <button
+              type="submit"
+              className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            >
               <Save size={20} />
-              {isEdit ? 'Salvar Alterações' : 'Cadastrar Tipo'}
+              {isEdit ? "Salvar Alterações" : "Cadastrar Tipo"}
             </button>
-            <Link href="/tipos-material" className="px-6 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200">Cancelar</Link>
+            <Link
+              href="/tipos-material"
+              className="px-6 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200"
+            >
+              Cancelar
+            </Link>
           </div>
         </form>
       </div>

--- a/src/front/app/components/TipoMaterialForm.tsx
+++ b/src/front/app/components/TipoMaterialForm.tsx
@@ -4,29 +4,28 @@ import { ArrowLeft, Save } from "lucide-react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useToast } from "./Toast";
 
 const API = process.env.NEXT_PUBLIC_API_URL;
 
 export default function TipoMaterialForm() {
   const { id } = useParams();
-  const isEdit = !!id;
   const router = useRouter();
+  const isEdit = !!id;
+  const { toast } = useToast();
 
   const [nome, setNome] = useState("");
-  const [descricao, setDescricao] = useState("");
   const [loading, setLoading] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isEdit) return;
-
     fetch(`${API}/tipo-material/${id}`)
-      .then((res) => res.json())
+      .then((r) => r.json())
       .then((data) => {
         setNome(data.nome ?? "");
-        setDescricao(data.descricao ?? "");
       })
-      .catch((err) => setErro(err.message));
+      .catch(() => setErro("Erro ao carregar tipo de material"));
   }, [id, isEdit]);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -39,30 +38,32 @@ export default function TipoMaterialForm() {
     }
 
     setLoading(true);
-
-    const body = {
-      nome: nome.trim(),
-      descricao: descricao.trim() || null,
-    };
+    const body = { nome: nome.trim() };
 
     try {
       const url = isEdit
         ? `${API}/tipo-material/${id}`
         : `${API}/tipo-material`;
-
       const method = isEdit ? "PUT" : "POST";
-
       const res = await fetch(url, {
         method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
-
       if (!res.ok) {
+        if (res.status === 409) {
+          setErro("Já existe um tipo de material com esse nome");
+          return;
+        }
         const data = await res.json().catch(() => ({}));
         throw new Error(data.error ?? "Erro ao salvar");
       }
-
+      toast(
+        isEdit
+          ? "Tipo de material atualizado com sucesso"
+          : "Tipo de material cadastrado com sucesso",
+        "success",
+      );
       router.push("/tipos-material");
     } catch (err: unknown) {
       setErro(err instanceof Error ? err.message : "Erro ao salvar");
@@ -89,6 +90,7 @@ export default function TipoMaterialForm() {
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-6">
+        {erro && <p className="text-red-600 mb-4">{erro}</p>}
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <h2 className="text-lg font-semibold text-gray-900 mb-4">
@@ -107,28 +109,21 @@ export default function TipoMaterialForm() {
                   className="w-full px-4 py-2 border border-gray-300 rounded-lg"
                 />
               </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Descrição
-                </label>
-                <textarea
-                  rows={3}
-                  value={descricao}
-                  onChange={(e) => setDescricao(e.target.value)}
-                  placeholder="Descrição do tipo de material..."
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
-                ></textarea>
-              </div>
             </div>
           </div>
 
           <div className="flex gap-4 pt-4 border-t border-gray-200">
             <button
               type="submit"
-              className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+              disabled={loading}
+              className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
             >
               <Save size={20} />
-              {isEdit ? "Salvar Alterações" : "Cadastrar Tipo"}
+              {loading
+                ? "Salvando..."
+                : isEdit
+                  ? "Salvar Alterações"
+                  : "Cadastrar Tipo"}
             </button>
             <Link
               href="/tipos-material"

--- a/src/front/app/components/TiposMaterialList.tsx
+++ b/src/front/app/components/TiposMaterialList.tsx
@@ -1,33 +1,114 @@
-import { Plus, Search, Edit2, Trash2 } from 'lucide-react';
-import Link from 'next/link';
+"use client";
+
+import { useEffect, useState } from "react";
+import { Plus, Search, Edit2, Trash2 } from "lucide-react";
+import { useToast } from "./Toast";
+import Link from "next/link";
+
+const API = process.env.NEXT_PUBLIC_API_URL;
+
+type TipoMaterial = {
+  id: number;
+  nome: string;
+};
 
 export default function TiposMaterialList() {
-  const tipos = [
-    { id: 1, nome: 'Informática', descricao: 'Equipamentos de informática e tecnologia', patrimonios: 85 },
-    { id: 2, nome: 'Mobiliário', descricao: 'Móveis e equipamentos de escritório', patrimonios: 120 },
-    { id: 3, nome: 'Eletrônicos', descricao: 'Equipamentos eletrônicos diversos', patrimonios: 43 },
-  ];
+  const [tipos, setTipos] = useState<TipoMaterial[]>([]);
+  const [busca, setBusca] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    fetch(`${API}/tipo-material`)
+      .then((r) => r.json())
+      .then(setTipos)
+      .catch(() => setErro("Erro ao carregar tipos de material"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleDelete(id: number) {
+    if (!confirm("Confirmar exclusão do tipo de material?")) return;
+    try {
+      const res = await fetch(`${API}/tipo-material/${id}`, {
+        method: "DELETE",
+      });
+      if (res.status === 409) {
+        const data = await res.json().catch(() => ({}));
+        const lista =
+          (
+            data.patrimonios as
+              | { numero_patrimonio: string; descricao: string }[]
+              | undefined
+          )
+            ?.map((p) => `• ${p.numero_patrimonio} — ${p.descricao}`)
+            .join("\n") ?? "";
+        toast(`${data.error}\n\n${lista}`, "error");
+        return;
+      }
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast(data.error ?? "Erro ao excluir tipo de material", "error");
+        return;
+      }
+      setTipos((prev) => prev.filter((t) => t.id !== id));
+      toast("Tipo de material excluído com sucesso", "success");
+    } catch {
+      toast("Erro ao excluir tipo de material", "error");
+    }
+  }
+
+  const filtrados = tipos.filter((t) =>
+    t.nome.toLowerCase().includes(busca.toLowerCase()),
+  );
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-gray-500">Carregando...</div>
+      </div>
+    );
+  }
+
+  if (erro) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-red-600">{erro}</div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 mb-2">Tipos de Material</h1>
-          <p className="text-gray-600">Gerencie as categorias de patrimônios</p>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+            Tipos de Material
+          </h1>
+          <p className="text-gray-600">Gerencie os tipos de material</p>
         </div>
-        <Link href="/tipos-material/novo" className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+        <Link
+          href="/tipos-material/novo"
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+        >
           <Plus size={20} />
           Novo Tipo
         </Link>
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-4">
-        <div className="flex gap-4">
-          <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
-            <input type="text" placeholder="Buscar por nome ou descrição..." className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg" />
-          </div>
-          <button className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200">Filtrar</button>
+        <div className="flex-1 relative">
+          <Search
+            className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"
+            size={20}
+          />
+          <input
+            type="text"
+            placeholder="Buscar por nome..."
+            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg"
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+          />
         </div>
       </div>
 
@@ -35,34 +116,46 @@ export default function TiposMaterialList() {
         <table className="w-full">
           <thead className="bg-gray-50 border-b border-gray-200">
             <tr>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Nome</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Descrição</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Patrimônios</th>
-              <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">Ações</th>
+              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">
+                Nome
+              </th>
+              <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">
+                Ações
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200">
-            {tipos.map((tipo) => (
-              <tr key={tipo.id} className="hover:bg-gray-50">
-                <td className="px-6 py-4 text-sm text-gray-900 font-medium">{tipo.nome}</td>
-                <td className="px-6 py-4 text-sm text-gray-600">{tipo.descricao}</td>
-                <td className="px-6 py-4">
-                  <span className="inline-flex px-2 py-1 text-xs rounded-full bg-green-50 text-green-600">
-                    {tipo.patrimonios} itens
-                  </span>
-                </td>
-                <td className="px-6 py-4">
-                  <div className="flex justify-end gap-2">
-                    <Link href={`/tipos-material/editar/${tipo.id}`} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg">
-                      <Edit2 size={18} />
-                    </Link>
-                    <button className="p-2 text-red-600 hover:bg-red-50 rounded-lg">
-                      <Trash2 size={18} />
-                    </button>
-                  </div>
+            {filtrados.length === 0 ? (
+              <tr>
+                <td colSpan={2} className="px-6 py-8 text-center text-gray-500">
+                  Nenhum tipo de material encontrado
                 </td>
               </tr>
-            ))}
+            ) : (
+              filtrados.map((tipo) => (
+                <tr key={tipo.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 text-sm text-gray-900 font-medium">
+                    {tipo.nome}
+                  </td>
+                  <td className="px-6 py-4">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/tipos-material/editar/${tipo.id}`}
+                        className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg"
+                      >
+                        <Edit2 size={16} />
+                      </Link>
+                      <button
+                        onClick={() => handleDelete(tipo.id)}
+                        className="p-2 text-red-600 hover:bg-red-50 rounded-lg"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>

--- a/src/front/app/components/__tests__/TiposMaterialList.test.tsx
+++ b/src/front/app/components/__tests__/TiposMaterialList.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TiposMaterialList from "../TiposMaterialList";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const mockToast = jest.fn();
+jest.mock("../Toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const tipos = [
+  { id: 1, nome: "Informática" },
+  { id: 2, nome: "Mobiliário" },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_API_URL = "http://localhost:8000/api";
+});
+
+function mockFetch(
+  handler: (
+    url: string,
+    opts?: RequestInit,
+  ) => { status: number; body: unknown },
+) {
+  global.fetch = jest.fn(async (url: RequestInfo | URL, opts?: RequestInit) => {
+    const { status, body } = handler(url.toString(), opts);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  }) as typeof fetch;
+}
+
+describe("TiposMaterialList", () => {
+  it("renderiza lista carregada da API", async () => {
+    mockFetch(() => ({ status: 200, body: tipos }));
+    render(<TiposMaterialList />);
+    await waitFor(() => {
+      expect(screen.getByText("Informática")).toBeInTheDocument();
+      expect(screen.getByText("Mobiliário")).toBeInTheDocument();
+    });
+  });
+
+  it("filtra por nome", async () => {
+    mockFetch(() => ({ status: 200, body: tipos }));
+    render(<TiposMaterialList />);
+    await waitFor(() => screen.getByText("Informática"));
+
+    await userEvent.type(screen.getByPlaceholderText(/buscar/i), "mob");
+
+    expect(screen.queryByText("Informática")).not.toBeInTheDocument();
+    expect(screen.getByText("Mobiliário")).toBeInTheDocument();
+  });
+
+  it("exibe erro ao falhar carregamento", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network"));
+    render(<TiposMaterialList />);
+    await waitFor(() =>
+      expect(screen.getByText(/erro ao carregar/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("delete com sucesso remove da lista e exibe toast", async () => {
+    mockFetch((_url, opts) => {
+      if (opts?.method === "DELETE") return { status: 204, body: null };
+      return { status: 200, body: tipos };
+    });
+    window.confirm = jest.fn(() => true);
+    render(<TiposMaterialList />);
+    await waitFor(() => screen.getByText("Informática"));
+
+    const deleteButtons = screen.getAllByRole("button");
+    await userEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Informática")).not.toBeInTheDocument();
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.stringMatching(/sucesso/i),
+        "success",
+      );
+    });
+  });
+
+  it("delete cancelado não chama API de delete", async () => {
+    mockFetch(() => ({ status: 200, body: tipos }));
+    window.confirm = jest.fn(() => false);
+    render(<TiposMaterialList />);
+    await waitFor(() => screen.getByText("Informática"));
+
+    const deleteButtons = screen.getAllByRole("button");
+    await userEvent.click(deleteButtons[0]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("409 com patrimônios vinculados exibe toast com lista", async () => {
+    const patrimonios = [
+      { id: 1, numero_patrimonio: "2024/001", descricao: "Computador Dell" },
+      { id: 2, numero_patrimonio: "2024/002", descricao: "Monitor LG" },
+    ];
+    mockFetch((_url, opts) => {
+      if (opts?.method === "DELETE")
+        return {
+          status: 409,
+          body: {
+            error:
+              "Tipo de material possui patrimônios vinculados e não pode ser excluído.",
+            patrimonios,
+          },
+        };
+      return { status: 200, body: tipos };
+    });
+    window.confirm = jest.fn(() => true);
+    render(<TiposMaterialList />);
+    await waitFor(() => screen.getByText("Informática"));
+
+    const deleteButtons = screen.getAllByRole("button");
+    await userEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.stringContaining("2024/001"),
+        "error",
+      );
+    });
+    expect(screen.getByText("Informática")).toBeInTheDocument();
+  });
+
+  it("erro genérico no delete exibe toast de erro", async () => {
+    mockFetch((_url, opts) => {
+      if (opts?.method === "DELETE")
+        return { status: 500, body: { error: "Erro interno do servidor" } };
+      return { status: 200, body: tipos };
+    });
+    window.confirm = jest.fn(() => true);
+    render(<TiposMaterialList />);
+    await waitFor(() => screen.getByText("Informática"));
+
+    const deleteButtons = screen.getAllByRole("button");
+    await userEvent.click(deleteButtons[0]);
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.stringMatching(/erro interno/i),
+        "error",
+      ),
+    );
+  });
+
+  it("exibe mensagem quando lista está vazia", async () => {
+    mockFetch(() => ({ status: 200, body: [] }));
+    render(<TiposMaterialList />);
+    await waitFor(() =>
+      expect(screen.getByText(/nenhum tipo de material/i)).toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## O que mudou
- Implementado CRUD para Tipos de Materiais.
- Adicionada persistência dos dados no banco de dados.
- Adicionado tratamento de erro para dados inválidos.
- Adicionados testes unitários para o endpoint.

## Por quê
- Para permitir o cadastro, consulta, atualização e remoção de Tipos de Materiais com suas características de identificação e relacionamentos corretos.
- Para garantir que dados inválidos sejam tratados adequadamente antes da persistência.

## Como testar
- Executar os testes unitários do endpoint.
- Criar um Tipo de Material válido e verificar se os dados são persistidos no banco.
- Enviar dados inválidos e validar se o erro esperado é retornado.
- Testar listagem, busca, atualização e remoção de Tipos de Materiais.

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
- [Risco] Validar se os relacionamentos obrigatórios estão sendo informados corretamente para evitar registros inconsistentes.
- [Manutenção] A lógica do CRUD foi mantida focada no recurso de Tipos de Materiais para facilitar futuras alterações.
- [Teste] Incluídos testes unitários cobrindo o endpoint e cenários de dados inválidos.