### PR TITLE
Feature/crud estado item

### DIFF
--- a/src/backend/src/controllers/EstadoItemController.ts
+++ b/src/backend/src/controllers/EstadoItemController.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { ForeignKeyConstraintError, UniqueConstraintError } from "sequelize";
+import { UniqueConstraintError } from "sequelize";
 import { EstadoItemService } from "../services/EstadoItemService";
 
 const service = new EstadoItemService();

--- a/src/backend/src/controllers/EstadoItemController.ts
+++ b/src/backend/src/controllers/EstadoItemController.ts
@@ -47,7 +47,13 @@ export const EstadoItemController = {
   async delete(req: Request, res: Response, next: NextFunction) {
     try {
       const id = Number(req.params.id);
-      //Verificar se tem patrimonios com este EstadoItem
+      const vinculados = await service.findPatrimoniosVinculados(id);
+      if (vinculados.length > 0) {
+        return res.status(409).json({
+          error: 'Estado de item possui patrimônios vinculados e não pode ser excluído. Reatribua os patrimônios antes de excluir.',
+          patrimonios: vinculados.map(p => ({ id: p.id, numero_patrimonio: p.numero_patrimonio, descricao: p.descricao })),
+        });
+      }
       const deleted = await service.delete(id);
       if (!deleted) return res.status(404).json({ error: 'Não encontrado' });
       res.status(204).send();

--- a/src/backend/src/controllers/EstadoItemController.ts
+++ b/src/backend/src/controllers/EstadoItemController.ts
@@ -1,0 +1,58 @@
+import { NextFunction, Request, Response } from "express";
+import { ForeignKeyConstraintError, UniqueConstraintError } from "sequelize";
+import { EstadoItemService } from "../services/EstadoItemService";
+
+const service = new EstadoItemService();
+
+export const EstadoItemController = {
+  async findAll(_req: Request, res: Response) {
+    const items = await service.findAll();
+    res.json(items);
+  },
+
+  async findById(req: Request, res: Response) {
+    const item = await service.findById(Number(req.params.id));
+    if (!item) return res.status(404).json({ error: "Não encontrado" });
+    res.json(item);
+  },
+
+  async create(req: Request, res: Response, next: NextFunction) {
+    const { nome } = req.body;
+
+    if (!nome || nome.trim() === '') {
+      return res.status(400).json({ error: 'nome é obrigatório' });
+    }
+
+    try {
+      const item = await service.create(req.body);
+      res.status(201).json(item);
+    } catch (err) {
+      if (err instanceof UniqueConstraintError) {
+        return res.status(409).json({ error: 'Já existe um estado de item com esses dados' });
+      }
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const item = await service.update(Number(req.params.id), req.body);
+      if (!item) return res.status(404).json({ error: 'Não encontrado' });
+      res.json(item);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const id = Number(req.params.id);
+      //Verificar se tem patrimonios com este EstadoItem
+      const deleted = await service.delete(id);
+      if (!deleted) return res.status(404).json({ error: 'Não encontrado' });
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/src/backend/src/repositories/EstadoItemRepository.ts
+++ b/src/backend/src/repositories/EstadoItemRepository.ts
@@ -1,0 +1,8 @@
+import { EstadoItem } from '../models/EstadoItem';
+import { BaseRepository } from './BaseRepository';
+
+export class EstadoItemRepository extends BaseRepository<EstadoItem> {
+  constructor() {
+    super(EstadoItem);
+  }
+}

--- a/src/backend/src/routes/estadoItem.routes.ts
+++ b/src/backend/src/routes/estadoItem.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { EstadoItemController } from "../controllers/EstadoItemController";
+
+const router = Router();
+
+router.get("/", EstadoItemController.findAll);
+router.get("/:id", EstadoItemController.findById);
+router.post("/", EstadoItemController.create);
+router.put("/:id", EstadoItemController.update);
+router.delete("/:id", EstadoItemController.delete);
+
+export default router;

--- a/src/backend/src/routes/index.ts
+++ b/src/backend/src/routes/index.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
 import ambienteRoutes from './ambiente.routes';
+import estadoItemRoutes from './estadoItem.routes';
 import responsavelRoutes from './responsavel.routes';
 
 const router = Router();
 
 router.use('/ambientes', ambienteRoutes);
+router.use('/estados-item', estadoItemRoutes);
 router.use('/responsaveis', responsavelRoutes);
 
 export default router;

--- a/src/backend/src/services/EstadoItemService.ts
+++ b/src/backend/src/services/EstadoItemService.ts
@@ -24,7 +24,7 @@ export class EstadoItemService {
 
   async findPatrimoniosVinculados(id: number) {
       return Patrimonio.findAll({
-        where: { ambiente_id: id },
+        where: { tipo_material_id: id },
         attributes: ['id', 'numero_patrimonio', 'descricao'],
       });
     }

--- a/src/backend/src/services/EstadoItemService.ts
+++ b/src/backend/src/services/EstadoItemService.ts
@@ -1,0 +1,27 @@
+import { CreationAttributes } from 'sequelize';
+import { EstadoItemRepository } from '../repositories/EstadoItemRepository';
+import { EstadoItem } from '../models/EstadoItem';
+
+export class EstadoItemService {
+  private repo = new EstadoItemRepository();
+
+  findAll() {
+    return this.repo.findAll();
+  }
+
+  findById(id: number) {
+    return this.repo.findById(id);
+  }
+
+  create(data: CreationAttributes<EstadoItem>) {
+    return this.repo.create(data);
+  }
+
+  update(id: number, data: Partial<CreationAttributes<EstadoItem>>) {
+    return this.repo.update(id, data);
+  }
+
+  delete(id: number) {
+    return this.repo.delete(id);
+  }
+}

--- a/src/backend/src/services/EstadoItemService.ts
+++ b/src/backend/src/services/EstadoItemService.ts
@@ -23,11 +23,11 @@ export class EstadoItemService {
   }
 
   async findPatrimoniosVinculados(id: number) {
-      return Patrimonio.findAll({
-        where: { tipo_material_id: id },
-        attributes: ['id', 'numero_patrimonio', 'descricao'],
-      });
-    }
+    return Patrimonio.findAll({
+      where: { estado_item_id: id },
+      attributes: ['id', 'numero_patrimonio', 'descricao'],
+    });
+  }
 
   delete(id: number) {
     return this.repo.delete(id);

--- a/src/backend/src/services/EstadoItemService.ts
+++ b/src/backend/src/services/EstadoItemService.ts
@@ -1,6 +1,7 @@
 import { CreationAttributes } from 'sequelize';
 import { EstadoItemRepository } from '../repositories/EstadoItemRepository';
 import { EstadoItem } from '../models/EstadoItem';
+import { Patrimonio } from '../models/Patrimonio';
 
 export class EstadoItemService {
   private repo = new EstadoItemRepository();
@@ -20,6 +21,13 @@ export class EstadoItemService {
   update(id: number, data: Partial<CreationAttributes<EstadoItem>>) {
     return this.repo.update(id, data);
   }
+
+  async findPatrimoniosVinculados(id: number) {
+      return Patrimonio.findAll({
+        where: { ambiente_id: id },
+        attributes: ['id', 'numero_patrimonio', 'descricao'],
+      });
+    }
 
   delete(id: number) {
     return this.repo.delete(id);

--- a/src/backend/tests/estadoItem.test.ts
+++ b/src/backend/tests/estadoItem.test.ts
@@ -1,0 +1,193 @@
+import request from 'supertest';
+import app from '../src/app';
+import { Patrimonio } from '../src/models/Patrimonio';
+import { EstadoItemService } from '../src/services/EstadoItemService';
+
+jest.mock('../src/services/EstadoItemService');
+jest.mock('../src/models/Patrimonio', () => ({
+  Patrimonio: {
+    findAll: jest.fn(),
+  },
+}));
+
+const MockedService = EstadoItemService as jest.MockedClass<typeof EstadoItemService>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('GET /api/estados-item', () => {
+  it('200 com lista de estados de item', async () => {
+    const list = [{ id: 1, nome: 'Bom', descricao: 'Em boas condicoes' }];
+    (MockedService.prototype.findAll as jest.Mock).mockResolvedValue(list);
+
+    const res = await request(app).get('/api/estados-item');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(list);
+  });
+});
+
+describe('GET /api/estados-item/:id', () => {
+  it('200 quando encontrado', async () => {
+    const item = { id: 1, nome: 'Bom', descricao: 'Em boas condicoes' };
+    (MockedService.prototype.findById as jest.Mock).mockResolvedValue(item);
+
+    const res = await request(app).get('/api/estados-item/1');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(item);
+  });
+
+  it('404 quando nao encontrado', async () => {
+    (MockedService.prototype.findById as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app).get('/api/estados-item/999');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'N\u00e3o encontrado' });
+  });
+});
+
+describe('POST /api/estados-item', () => {
+  it('201 com body valido', async () => {
+    const created = { id: 1, nome: 'Bom', descricao: 'Em boas condicoes' };
+    (MockedService.prototype.create as jest.Mock).mockResolvedValue(created);
+
+    const res = await request(app)
+      .post('/api/estados-item')
+      .send({ nome: 'Bom', descricao: 'Em boas condicoes' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(created);
+  });
+
+  it('400 sem nome', async () => {
+    const res = await request(app)
+      .post('/api/estados-item')
+      .send({ descricao: 'Sem nome' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'nome \u00e9 obrigat\u00f3rio' });
+  });
+
+  it('400 nome vazio', async () => {
+    const res = await request(app)
+      .post('/api/estados-item')
+      .send({ nome: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'nome \u00e9 obrigat\u00f3rio' });
+  });
+
+  it('500 quando service lanca erro', async () => {
+    (MockedService.prototype.create as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app)
+      .post('/api/estados-item')
+      .send({ nome: 'Bom' });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Erro interno do servidor' });
+  });
+});
+
+describe('EstadoItemService.findPatrimoniosVinculados', () => {
+  it('busca patrimonios pelo campo estado_item_id', async () => {
+    const patrimonios = [{ id: 1, numero_patrimonio: '2024/001', descricao: 'Notebook' }];
+    (Patrimonio.findAll as jest.Mock).mockResolvedValue(patrimonios);
+    const { EstadoItemService: ActualEstadoItemService } = jest.requireActual('../src/services/EstadoItemService');
+
+    const service = new ActualEstadoItemService();
+    const result = await service.findPatrimoniosVinculados(7);
+
+    expect(result).toEqual(patrimonios);
+    expect(Patrimonio.findAll).toHaveBeenCalledWith({
+      where: { estado_item_id: 7 },
+      attributes: ['id', 'numero_patrimonio', 'descricao'],
+    });
+  });
+});
+
+describe('PUT /api/estados-item/:id', () => {
+  const updated = { id: 1, nome: 'Regular', descricao: 'Uso com restricoes' };
+
+  it('200 com dados validos', async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(updated);
+
+    const res = await request(app)
+      .put('/api/estados-item/1')
+      .send({ nome: 'Regular' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(updated);
+  });
+
+  it('404 quando id nao existe', async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app)
+      .put('/api/estados-item/999')
+      .send({ nome: 'Regular' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'N\u00e3o encontrado' });
+  });
+
+  it('500 quando service lanca erro', async () => {
+    (MockedService.prototype.update as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app)
+      .put('/api/estados-item/1')
+      .send({ nome: 'Regular' });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Erro interno do servidor' });
+  });
+});
+
+describe('DELETE /api/estados-item/:id', () => {
+  it('204 quando removido sem vinculos', async () => {
+    (MockedService.prototype.findPatrimoniosVinculados as jest.Mock).mockResolvedValue([]);
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(true);
+
+    const res = await request(app).delete('/api/estados-item/1');
+
+    expect(res.status).toBe(204);
+    expect(res.body).toEqual({});
+  });
+
+  it('404 quando id nao existe', async () => {
+    (MockedService.prototype.findPatrimoniosVinculados as jest.Mock).mockResolvedValue([]);
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(false);
+
+    const res = await request(app).delete('/api/estados-item/999');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'N\u00e3o encontrado' });
+  });
+
+  it('409 quando possui patrimonios vinculados', async () => {
+    const patrimonios = [
+      { id: 1, numero_patrimonio: '2024/001', descricao: 'Computador Dell' },
+      { id: 2, numero_patrimonio: '2024/002', descricao: 'Monitor LG' },
+    ];
+    (MockedService.prototype.findPatrimoniosVinculados as jest.Mock).mockResolvedValue(patrimonios);
+
+    const res = await request(app).delete('/api/estados-item/1');
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/patrim\u00f4nios vinculados/);
+    expect(res.body.patrimonios).toHaveLength(2);
+    expect(res.body.patrimonios[0]).toMatchObject({ numero_patrimonio: '2024/001', descricao: 'Computador Dell' });
+  });
+
+  it('500 quando service lanca erro', async () => {
+    (MockedService.prototype.findPatrimoniosVinculados as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+    const res = await request(app).delete('/api/estados-item/1');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Erro interno do servidor' });
+  });
+});

--- a/src/front/app/components/EstadoItemForm.tsx
+++ b/src/front/app/components/EstadoItemForm.tsx
@@ -1,12 +1,77 @@
 'use client'
 
+import { useEffect, useState } from 'react';
 import { ArrowLeft, Save } from 'lucide-react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
+import { useToast } from './Toast';
+
+const API = process.env.NEXT_PUBLIC_API_URL;
 
 export default function EstadoItemForm() {
   const { id } = useParams();
+  const router = useRouter();
   const isEdit = !!id;
+  const { toast } = useToast();
+
+  const [nome, setNome] = useState('');
+  const [descricao, setDescricao] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isEdit) return;
+
+    fetch(`${API}/estados-item/${id}`)
+      .then(r => r.json())
+      .then(data => {
+        setNome(data.nome ?? '');
+        setDescricao(data.descricao ?? '');
+      })
+      .catch(() => setErro('Erro ao carregar estado do item'));
+  }, [id, isEdit]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErro(null);
+
+    if (!nome.trim()) {
+      setErro('Nome e obrigatorio');
+      return;
+    }
+
+    setLoading(true);
+    const body = {
+      nome: nome.trim(),
+      descricao: descricao.trim() || null,
+    };
+
+    try {
+      const url = isEdit ? `${API}/estados-item/${id}` : `${API}/estados-item`;
+      const method = isEdit ? 'PUT' : 'POST';
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        if (res.status === 409) {
+          setErro('Ja existe um estado do item com esses dados');
+          return;
+        }
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? 'Erro ao salvar');
+      }
+
+      toast(isEdit ? 'Estado do item atualizado com sucesso' : 'Estado do item cadastrado com sucesso', 'success');
+      router.push('/estados-item');
+    } catch (err: unknown) {
+      setErro(err instanceof Error ? err.message : 'Erro ao salvar');
+    } finally {
+      setLoading(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -21,36 +86,43 @@ export default function EstadoItemForm() {
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <form className="space-y-6">
+        {erro && <p className="text-red-600 mb-4">{erro}</p>}
+        <form onSubmit={handleSubmit} className="space-y-6">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Informações do Estado</h2>
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Informacoes do Estado</h2>
             <div className="grid grid-cols-1 gap-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">Nome do Estado *</label>
-                <input type="text" placeholder="Ex: Ativo" className="w-full px-4 py-2 border border-gray-300 rounded-lg" />
+                <input
+                  type="text"
+                  placeholder="Ex: Ativo"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={nome}
+                  onChange={e => setNome(e.target.value)}
+                  required
+                />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Descrição</label>
-                <textarea rows={3} placeholder="Descrição do estado..." className="w-full px-4 py-2 border border-gray-300 rounded-lg"></textarea>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Cor de Identificação</label>
-                <select className="w-full px-4 py-2 border border-gray-300 rounded-lg">
-                  <option value="">Selecione...</option>
-                  <option value="green">Verde (Ativo)</option>
-                  <option value="orange">Laranja (Em Manutenção)</option>
-                  <option value="red">Vermelho (Avariado)</option>
-                  <option value="gray">Cinza (Inativo)</option>
-                  <option value="blue">Azul (Outro)</option>
-                </select>
+                <label className="block text-sm font-medium text-gray-700 mb-2">Descricao</label>
+                <textarea
+                  rows={3}
+                  placeholder="Descricao do estado..."
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={descricao}
+                  onChange={e => setDescricao(e.target.value)}
+                />
               </div>
             </div>
           </div>
 
           <div className="flex gap-4 pt-4 border-t border-gray-200">
-            <button type="submit" className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+            >
               <Save size={20} />
-              {isEdit ? 'Salvar Alterações' : 'Cadastrar Estado'}
+              {loading ? 'Salvando...' : isEdit ? 'Salvar Alteracoes' : 'Cadastrar Estado'}
             </button>
             <Link href="/estados-item" className="px-6 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200">Cancelar</Link>
           </div>

--- a/src/front/app/components/EstadosItemList.tsx
+++ b/src/front/app/components/EstadosItemList.tsx
@@ -1,21 +1,86 @@
+'use client'
+
+import { useEffect, useState } from 'react';
 import { Plus, Search, Edit2, Trash2 } from 'lucide-react';
 import Link from 'next/link';
+import { useToast } from './Toast';
+
+const API = process.env.NEXT_PUBLIC_API_URL;
+
+type EstadoItem = {
+  id: number;
+  nome: string;
+  descricao: string | null;
+};
 
 export default function EstadosItemList() {
-  const estados = [
-    { id: 1, nome: 'Ativo', descricao: 'Item em pleno funcionamento', cor: 'bg-green-100 text-green-800', patrimonios: 185 },
-    { id: 2, nome: 'Em Manutenção', descricao: 'Item em processo de manutenção', cor: 'bg-orange-100 text-orange-800', patrimonios: 12 },
-    { id: 3, nome: 'Avariado', descricao: 'Item com problemas, necessita reparo', cor: 'bg-red-100 text-red-800', patrimonios: 8 },
-    { id: 4, nome: 'Inativo', descricao: 'Item fora de uso temporariamente', cor: 'bg-gray-100 text-gray-800', patrimonios: 35 },
-    { id: 5, nome: 'Descartado', descricao: 'Item descartado ou inutilizado', cor: 'bg-gray-200 text-gray-600', patrimonios: 8 },
-  ];
+  const [estados, setEstados] = useState<EstadoItem[]>([]);
+  const [busca, setBusca] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    fetch(`${API}/estados-item`)
+      .then(r => r.json())
+      .then(setEstados)
+      .catch(() => setErro('Erro ao carregar estados do item'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleDelete(id: number) {
+    if (!confirm('Confirmar exclusao do estado do item?')) return;
+
+    try {
+      const res = await fetch(`${API}/estados-item/${id}`, { method: 'DELETE' });
+      if (res.status === 409) {
+        const data = await res.json().catch(() => ({}));
+        const lista = (data.patrimonios as { numero_patrimonio: string; descricao: string }[] | undefined)
+          ?.map(p => `- ${p.numero_patrimonio} - ${p.descricao}`)
+          .join('\n') ?? '';
+        toast(`${data.error}\n\n${lista}`, 'error');
+        return;
+      }
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast(data.error ?? 'Erro ao excluir estado do item', 'error');
+        return;
+      }
+
+      setEstados(prev => prev.filter(estado => estado.id !== id));
+      toast('Estado do item excluido com sucesso', 'success');
+    } catch {
+      toast('Erro ao excluir estado do item', 'error');
+    }
+  }
+
+  const filtrados = estados.filter(estado =>
+    estado.nome.toLowerCase().includes(busca.toLowerCase()) ||
+    (estado.descricao ?? '').toLowerCase().includes(busca.toLowerCase())
+  );
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-gray-500">Carregando...</div>
+      </div>
+    );
+  }
+
+  if (erro) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-red-600">{erro}</div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 mb-2">Estados do Item</h1>
-          <p className="text-gray-600">Gerencie os possíveis estados dos patrimônios</p>
+          <p className="text-gray-600">Gerencie os possiveis estados dos patrimonios</p>
         </div>
         <Link href="/estados-item/novo" className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
           <Plus size={20} />
@@ -24,12 +89,15 @@ export default function EstadosItemList() {
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-4">
-        <div className="flex gap-4">
-          <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
-            <input type="text" placeholder="Buscar por nome ou descrição..." className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg" />
-          </div>
-          <button className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200">Filtrar</button>
+        <div className="flex-1 relative">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
+          <input
+            type="text"
+            placeholder="Buscar por nome ou descricao..."
+            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg"
+            value={busca}
+            onChange={e => setBusca(e.target.value)}
+          />
         </div>
       </div>
 
@@ -38,37 +106,38 @@ export default function EstadosItemList() {
           <thead className="bg-gray-50 border-b border-gray-200">
             <tr>
               <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Nome</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Descrição</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Patrimônios</th>
-              <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">Ações</th>
+              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Descricao</th>
+              <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">Acoes</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200">
-            {estados.map((estado) => (
-              <tr key={estado.id} className="hover:bg-gray-50">
-                <td className="px-6 py-4 text-sm">
-                  <span className={`inline-flex px-3 py-1 rounded-full font-medium ${estado.cor}`}>
-                    {estado.nome}
-                  </span>
-                </td>
-                <td className="px-6 py-4 text-sm text-gray-600">{estado.descricao}</td>
-                <td className="px-6 py-4">
-                  <span className="inline-flex px-2 py-1 text-xs rounded-full bg-blue-50 text-blue-600">
-                    {estado.patrimonios} itens
-                  </span>
-                </td>
-                <td className="px-6 py-4">
-                  <div className="flex justify-end gap-2">
-                    <Link href={`/estados-item/editar/${estado.id}`} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg">
-                      <Edit2 size={18} />
-                    </Link>
-                    <button className="p-2 text-red-600 hover:bg-red-50 rounded-lg">
-                      <Trash2 size={18} />
-                    </button>
-                  </div>
+            {filtrados.length === 0 ? (
+              <tr>
+                <td colSpan={3} className="px-6 py-8 text-center text-gray-500">
+                  Nenhum estado do item encontrado.
                 </td>
               </tr>
-            ))}
+            ) : (
+              filtrados.map((estado) => (
+                <tr key={estado.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 text-sm text-gray-900 font-medium">{estado.nome}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{estado.descricao ?? '-'}</td>
+                  <td className="px-6 py-4">
+                    <div className="flex justify-end gap-2">
+                      <Link href={`/estados-item/editar/${estado.id}`} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg">
+                        <Edit2 size={18} />
+                      </Link>
+                      <button
+                        onClick={() => handleDelete(estado.id)}
+                        className="p-2 text-red-600 hover:bg-red-50 rounded-lg"
+                      >
+                        <Trash2 size={18} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>

--- a/src/front/app/components/SidebarLayout.tsx
+++ b/src/front/app/components/SidebarLayout.tsx
@@ -16,16 +16,9 @@ const menuItems = [
   { path: '/estados-item', icon: AlertCircle, label: 'Estados do Item' },
 ];
 
-const implementedRoutes: string[] = [
-  '/ambientes',
-  '/responsaveis',
-];
-
 export default function SidebarLayout({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [showBanner, setShowBanner] = useState(true);
   const pathname = usePathname();
-  const isPrototype = !implementedRoutes.some((prefix) => pathname === prefix || pathname.startsWith(prefix + '/'));
 
   return (
     <div className="flex h-screen bg-gray-50">
@@ -68,20 +61,6 @@ export default function SidebarLayout({ children }: { children: React.ReactNode 
           </div>
         </header>
 
-        {showBanner && isPrototype && (
-          <div className="bg-amber-50 border-b border-amber-200 px-6 py-3 flex items-center justify-between gap-4">
-            <div className="flex items-center gap-2 text-amber-800 text-sm">
-              <span className="font-semibold">⚠ Protótipo</span>
-              <span>Esta aplicação está em desenvolvimento. As funcionalidades desta página ainda não foram implementadas.</span>
-            </div>
-            <button
-              onClick={() => setShowBanner(false)}
-              className="text-amber-600 hover:text-amber-800 font-medium text-sm shrink-0"
-            >
-              Fechar
-            </button>
-          </div>
-        )}
         <main className="flex-1 overflow-auto p-6">
           {children}
         </main>

--- a/src/front/app/components/__tests__/EstadoItemForm.test.tsx
+++ b/src/front/app/components/__tests__/EstadoItemForm.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EstadoItemForm from '../EstadoItemForm';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+const mockPush = jest.fn();
+let mockParams: Record<string, string | undefined> = {};
+jest.mock('next/navigation', () => ({
+  useParams: () => mockParams,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockToast = jest.fn();
+jest.mock('../Toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockParams = {};
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000/api';
+  global.fetch = jest.fn() as typeof fetch;
+});
+
+function mockFetch(handler: (url: string, opts?: RequestInit) => { status: number; body: unknown }) {
+  global.fetch = jest.fn(async (url: RequestInfo | URL, opts?: RequestInit) => {
+    const { status, body } = handler(url.toString(), opts);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  }) as typeof fetch;
+}
+
+describe('EstadoItemForm', () => {
+  it('cadastra novo estado do item e redireciona para a lista', async () => {
+    mockFetch((_url, opts) => {
+      expect(opts?.method).toBe('POST');
+      expect(JSON.parse(opts?.body as string)).toEqual({
+        nome: 'Disponivel',
+        descricao: 'Pronto para uso',
+      });
+      return { status: 201, body: { id: 1 } };
+    });
+
+    render(<EstadoItemForm />);
+
+    await userEvent.type(screen.getByPlaceholderText('Ex: Ativo'), ' Disponivel ');
+    await userEvent.type(screen.getByPlaceholderText(/descricao do estado/i), ' Pronto para uso ');
+    await userEvent.click(screen.getByRole('button', { name: /cadastrar estado/i }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith('Estado do item cadastrado com sucesso', 'success');
+      expect(mockPush).toHaveBeenCalledWith('/estados-item');
+    });
+  });
+
+  it('carrega dados existentes e atualiza estado do item', async () => {
+    mockParams = { id: '7' };
+    mockFetch((_url, opts) => {
+      if (!opts?.method) {
+        return { status: 200, body: { id: 7, nome: 'Ativo', descricao: 'Em uso' } };
+      }
+      expect(opts.method).toBe('PUT');
+      expect(JSON.parse(opts.body as string)).toEqual({
+        nome: 'Ativo revisado',
+        descricao: 'Em uso',
+      });
+      return { status: 200, body: { id: 7 } };
+    });
+
+    render(<EstadoItemForm />);
+
+    const nome = await screen.findByDisplayValue('Ativo');
+    await userEvent.clear(nome);
+    await userEvent.type(nome, 'Ativo revisado');
+    await userEvent.click(screen.getByRole('button', { name: /salvar alteracoes/i }));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith('Estado do item atualizado com sucesso', 'success');
+      expect(mockPush).toHaveBeenCalledWith('/estados-item');
+    });
+  });
+
+  it('exibe validacao quando nome esta vazio', async () => {
+    render(<EstadoItemForm />);
+
+    fireEvent.submit(screen.getByRole('button', { name: /cadastrar estado/i }).closest('form')!);
+
+    expect(await screen.findByText('Nome e obrigatorio')).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('exibe erro de conflito ao receber 409', async () => {
+    mockFetch(() => ({ status: 409, body: { error: 'Duplicado' } }));
+    render(<EstadoItemForm />);
+
+    await userEvent.type(screen.getByPlaceholderText('Ex: Ativo'), 'Ativo');
+    await userEvent.click(screen.getByRole('button', { name: /cadastrar estado/i }));
+
+    expect(await screen.findByText(/ja existe um estado do item/i)).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('exibe erro quando falha ao carregar para edicao', async () => {
+    mockParams = { id: '9' };
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network'));
+
+    render(<EstadoItemForm />);
+
+    expect(await screen.findByText(/erro ao carregar estado do item/i)).toBeInTheDocument();
+  });
+});

--- a/src/front/app/components/__tests__/EstadosItemList.test.tsx
+++ b/src/front/app/components/__tests__/EstadosItemList.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EstadosItemList from '../EstadosItemList';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+const mockToast = jest.fn();
+jest.mock('../Toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const estados = [
+  { id: 1, nome: 'Ativo', descricao: 'Item em uso' },
+  { id: 2, nome: 'Manutencao', descricao: null },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000/api';
+});
+
+function mockFetch(handler: (url: string, opts?: RequestInit) => { status: number; body: unknown }) {
+  global.fetch = jest.fn(async (url: RequestInfo | URL, opts?: RequestInit) => {
+    const { status, body } = handler(url.toString(), opts);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  }) as typeof fetch;
+}
+
+describe('EstadosItemList', () => {
+  it('renderiza lista carregada da API', async () => {
+    mockFetch(() => ({ status: 200, body: estados }));
+
+    render(<EstadosItemList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ativo')).toBeInTheDocument();
+      expect(screen.getByText('Manutencao')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Item em uso')).toBeInTheDocument();
+  });
+
+  it('filtra por nome', async () => {
+    mockFetch(() => ({ status: 200, body: estados }));
+    render(<EstadosItemList />);
+    await waitFor(() => screen.getByText('Ativo'));
+
+    await userEvent.type(screen.getByPlaceholderText(/buscar/i), 'manutencao');
+
+    expect(screen.queryByText('Ativo')).not.toBeInTheDocument();
+    expect(screen.getByText('Manutencao')).toBeInTheDocument();
+  });
+
+  it('filtra por descricao', async () => {
+    mockFetch(() => ({ status: 200, body: estados }));
+    render(<EstadosItemList />);
+    await waitFor(() => screen.getByText('Ativo'));
+
+    await userEvent.type(screen.getByPlaceholderText(/buscar/i), 'uso');
+
+    expect(screen.getByText('Ativo')).toBeInTheDocument();
+    expect(screen.queryByText('Manutencao')).not.toBeInTheDocument();
+  });
+
+  it('exibe estado vazio quando filtro nao encontra registros', async () => {
+    mockFetch(() => ({ status: 200, body: estados }));
+    render(<EstadosItemList />);
+    await waitFor(() => screen.getByText('Ativo'));
+
+    await userEvent.type(screen.getByPlaceholderText(/buscar/i), 'baixado');
+
+    expect(screen.getByText(/nenhum estado do item encontrado/i)).toBeInTheDocument();
+  });
+
+  it('exibe erro ao falhar carregamento', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network'));
+
+    render(<EstadosItemList />);
+
+    await waitFor(() => expect(screen.getByText(/erro ao carregar estados do item/i)).toBeInTheDocument());
+  });
+
+  it('delete com sucesso remove da lista e exibe toast', async () => {
+    mockFetch((_url, opts) => {
+      if (opts?.method === 'DELETE') return { status: 204, body: null };
+      return { status: 200, body: estados };
+    });
+    window.confirm = jest.fn(() => true);
+    render(<EstadosItemList />);
+    await waitFor(() => screen.getByText('Ativo'));
+
+    await userEvent.click(screen.getAllByRole('button')[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Ativo')).not.toBeInTheDocument();
+      expect(mockToast).toHaveBeenCalledWith(expect.stringMatching(/sucesso/i), 'success');
+    });
+  });
+
+  it('delete cancelado nao chama a API de exclusao', async () => {
+    mockFetch(() => ({ status: 200, body: estados }));
+    window.confirm = jest.fn(() => false);
+    render(<EstadosItemList />);
+    await waitFor(() => screen.getByText('Ativo'));
+
+    await userEvent.click(screen.getAllByRole('button')[0]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('409 com patrimonios vinculados exibe toast com lista', async () => {
+    const patrimonios = [
+      { numero_patrimonio: '2024/001', descricao: 'Notebook Dell' },
+      { numero_patrimonio: '2024/002', descricao: 'Monitor LG' },
+    ];
+    mockFetch((_url, opts) => {
+      if (opts?.method === 'DELETE') {
+        return {
+          status: 409,
+          body: { error: 'Estado possui patrimonios vinculados.', patrimonios },
+        };
+      }
+      return { status: 200, body: estados };
+    });
+    window.confirm = jest.fn(() => true);
+    render(<EstadosItemList />);
+    await waitFor(() => screen.getByText('Ativo'));
+
+    await userEvent.click(screen.getAllByRole('button')[0]);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(expect.stringContaining('2024/001'), 'error');
+      expect(mockToast).toHaveBeenCalledWith(expect.stringContaining('Notebook Dell'), 'error');
+    });
+    expect(screen.getByText('Ativo')).toBeInTheDocument();
+  });
+
+  it('erro generico ao excluir exibe toast de erro', async () => {
+    mockFetch((_url, opts) => {
+      if (opts?.method === 'DELETE') return { status: 500, body: { error: 'Erro interno do servidor' } };
+      return { status: 200, body: estados };
+    });
+    window.confirm = jest.fn(() => true);
+    render(<EstadosItemList />);
+    await waitFor(() => screen.getByText('Ativo'));
+
+    await userEvent.click(screen.getAllByRole('button')[0]);
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith(expect.stringMatching(/erro interno/i), 'error'));
+  });
+});

--- a/src/front/jest.config.mjs
+++ b/src/front/jest.config.mjs
@@ -1,9 +1,8 @@
-import type { Config } from 'jest';
 import nextJest from 'next/jest.js';
 
 const createJestConfig = nextJest({ dir: './' });
 
-const config: Config = {
+const config = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {


### PR DESCRIPTION
## O que mudou
- Adicionado CRUD de Estados do Item no backend com controller, service, repository e rotas em `/api/estados-item`.
- Integrada a listagem e o formulário de Estados do Item ao frontend, substituindo dados fixos por chamadas à API.
- Adicionada busca por nome/descrição, estados de carregamento/erro, criação, edição e exclusão.
- Bloqueada a exclusão de estado do item quando houver patrimônios vinculados, retornando erro `409` com a lista de patrimônios.
- Adicionados testes automatizados para listagem, busca por ID, criação, atualização, exclusão e casos de erro.

## Por quê
- Permitir gerenciar os possíveis estados dos patrimônios diretamente pelo sistema.
- Evitar exclusões que deixariam patrimônios com referência inválida para estado do item.
- Remover dependência de dados mockados no frontend e conectar a tela ao fluxo real da aplicação.

## Como testar
- No backend, executar:
  `npm test -- estadoItem.test.ts`
- Iniciar backend e frontend com `NEXT_PUBLIC_API_URL` apontando para a API.
- Acessar a tela de Estados do Item.
- Criar um estado com nome e descrição.
- Editar o estado criado e confirmar se os dados são carregados no formulário.
- Buscar pelo nome ou descrição na listagem.
- Excluir um estado sem patrimônios vinculados e confirmar remoção da lista.
- Tentar excluir um estado com patrimônios vinculados e verificar se o sistema exibe o erro de bloqueio.

## Auto-review (checklist)
- [ ] Descrição clara (o que/por quê/como testar)
- [ ] PR pequeno e focado
- [ ] Casos limite considerados (ex.: vazio, 0, erro)
- [ ] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
- [Risco] A exclusão depende da verificação de patrimônios vinculados por `estado_item_id`; é importante validar se esse campo está consistente com o modelo e banco.
- [Manutenção] A implementação segue o padrão controller/service/repository já usado no backend, mantendo a separação de responsabilidades.
- [Teste] Foram adicionados testes para fluxos felizes e erros comuns: `404`, `400`, `409` e `500`.
- [Risco] O frontend depende de `NEXT_PUBLIC_API_URL`; se a variável não estiver configurada, as chamadas à API podem falhar.