### PR TITLE
Feature/crud conferentes

### DIFF
--- a/src/backend/src/controllers/ConferenteController.ts
+++ b/src/backend/src/controllers/ConferenteController.ts
@@ -1,0 +1,55 @@
+import { NextFunction, Request, Response } from "express";
+import { ConferenteService } from "../services/ConferenteService";
+
+const service = new ConferenteService();
+
+export const ConferenteController = {
+  async findAll(_req: Request, res: Response) {
+    const items = await service.findAll();
+    res.json(items);
+  },
+
+  async findById(req: Request, res: Response) {
+    const item = await service.findById(Number(req.params.id));
+    if (!item) return res.status(404).json({ error: "N\u00e3o encontrado" });
+    res.json(item);
+  },
+
+  async create(req: Request, res: Response, next: NextFunction) {
+    const { nome, email } = req.body;
+
+    if (!nome || nome.trim() === "") {
+      return res.status(400).json({ error: "nome \u00e9 obrigat\u00f3rio" });
+    }
+    if (!email || email.trim() === "") {
+      return res.status(400).json({ error: "email \u00e9 obrigat\u00f3rio" });
+    }
+
+    try {
+      const item = await service.create(req.body);
+      res.status(201).json(item);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const item = await service.update(Number(req.params.id), req.body);
+      if (!item) return res.status(404).json({ error: "N\u00e3o encontrado" });
+      res.json(item);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const deleted = await service.delete(Number(req.params.id));
+      if (!deleted) return res.status(404).json({ error: "N\u00e3o encontrado" });
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/src/backend/src/repositories/ConferenteRepository.ts
+++ b/src/backend/src/repositories/ConferenteRepository.ts
@@ -1,0 +1,8 @@
+import { Conferente } from "../models/Conferente";
+import { BaseRepository } from "./BaseRepository";
+
+export class ConferenteRepository extends BaseRepository<Conferente> {
+  constructor() {
+    super(Conferente);
+  }
+}

--- a/src/backend/src/routes/conferente.routes.ts
+++ b/src/backend/src/routes/conferente.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { ConferenteController } from "../controllers/ConferenteController";
+
+const router = Router();
+
+router.get("/", ConferenteController.findAll);
+router.get("/:id", ConferenteController.findById);
+router.post("/", ConferenteController.create);
+router.put("/:id", ConferenteController.update);
+router.delete("/:id", ConferenteController.delete);
+
+export default router;

--- a/src/backend/src/routes/index.ts
+++ b/src/backend/src/routes/index.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import ambienteRoutes from "./ambiente.routes";
+import conferenteRoutes from "./conferente.routes";
 import fornecedoresRoutes from "./fornecedores.routes";
 import responsavelRoutes from "./responsavel.routes";
 import tipoMaterialRoutes from "./tipoMaterial.routes";
@@ -7,6 +8,7 @@ import tipoMaterialRoutes from "./tipoMaterial.routes";
 const router = Router();
 
 router.use("/ambientes", ambienteRoutes);
+router.use("/conferentes", conferenteRoutes);
 router.use("/fornecedores", fornecedoresRoutes);
 router.use("/responsaveis", responsavelRoutes);
 router.use("/tipo-material", tipoMaterialRoutes);

--- a/src/backend/src/services/ConferenteService.ts
+++ b/src/backend/src/services/ConferenteService.ts
@@ -1,0 +1,27 @@
+import { CreationAttributes } from "sequelize";
+import { Conferente } from "../models/Conferente";
+import { ConferenteRepository } from "../repositories/ConferenteRepository";
+
+export class ConferenteService {
+  private repo = new ConferenteRepository();
+
+  findAll() {
+    return this.repo.findAll();
+  }
+
+  findById(id: number) {
+    return this.repo.findById(id);
+  }
+
+  create(data: CreationAttributes<Conferente>) {
+    return this.repo.create(data);
+  }
+
+  update(id: number, data: Partial<CreationAttributes<Conferente>>) {
+    return this.repo.update(id, data);
+  }
+
+  delete(id: number) {
+    return this.repo.delete(id);
+  }
+}

--- a/src/backend/tests/conferente.test.ts
+++ b/src/backend/tests/conferente.test.ts
@@ -1,0 +1,180 @@
+import request from "supertest";
+import app from "../src/app";
+import { ConferenteService } from "../src/services/ConferenteService";
+
+jest.mock("../src/services/ConferenteService");
+
+const MockedService = ConferenteService as jest.MockedClass<typeof ConferenteService>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("GET /api/conferentes", () => {
+  it("200 com lista de conferentes", async () => {
+    const list = [
+      { id: 1, nome: "Ana Silva", email: "ana@test.com", cargo: "Tecnica", telefone: null },
+    ];
+    (MockedService.prototype.findAll as jest.Mock).mockResolvedValue(list);
+
+    const res = await request(app).get("/api/conferentes");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(list);
+  });
+});
+
+describe("GET /api/conferentes/:id", () => {
+  it("200 quando encontrado", async () => {
+    const item = { id: 1, nome: "Ana Silva", email: "ana@test.com", cargo: "Tecnica", telefone: null };
+    (MockedService.prototype.findById as jest.Mock).mockResolvedValue(item);
+
+    const res = await request(app).get("/api/conferentes/1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(item);
+  });
+
+  it("404 quando nao encontrado", async () => {
+    (MockedService.prototype.findById as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app).get("/api/conferentes/999");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "N\u00e3o encontrado" });
+  });
+});
+
+describe("POST /api/conferentes", () => {
+  it("201 com body valido", async () => {
+    const created = { id: 1, nome: "Ana Silva", email: "ana@test.com", cargo: "Tecnica", telefone: null };
+    (MockedService.prototype.create as jest.Mock).mockResolvedValue(created);
+
+    const res = await request(app)
+      .post("/api/conferentes")
+      .send({ nome: "Ana Silva", email: "ana@test.com", cargo: "Tecnica" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(created);
+  });
+
+  it("400 sem nome", async () => {
+    const res = await request(app)
+      .post("/api/conferentes")
+      .send({ email: "ana@test.com" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "nome \u00e9 obrigat\u00f3rio" });
+  });
+
+  it("400 nome vazio", async () => {
+    const res = await request(app)
+      .post("/api/conferentes")
+      .send({ nome: "", email: "ana@test.com" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "nome \u00e9 obrigat\u00f3rio" });
+  });
+
+  it("400 sem email", async () => {
+    const res = await request(app)
+      .post("/api/conferentes")
+      .send({ nome: "Ana Silva" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "email \u00e9 obrigat\u00f3rio" });
+  });
+
+  it("400 email vazio", async () => {
+    const res = await request(app)
+      .post("/api/conferentes")
+      .send({ nome: "Ana Silva", email: "" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "email \u00e9 obrigat\u00f3rio" });
+  });
+
+  it("400 sem nome e sem email", async () => {
+    const res = await request(app).post("/api/conferentes").send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "nome \u00e9 obrigat\u00f3rio" });
+  });
+
+  it("500 quando service lanca erro", async () => {
+    (MockedService.prototype.create as jest.Mock).mockRejectedValue(new Error("DB error"));
+
+    const res = await request(app)
+      .post("/api/conferentes")
+      .send({ nome: "Ana Silva", email: "ana@test.com" });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Erro interno do servidor" });
+  });
+});
+
+describe("PUT /api/conferentes/:id", () => {
+  const updated = { id: 1, nome: "Ana Atualizada", email: "ana@test.com", cargo: "Tecnica", telefone: null };
+
+  it("200 com dados validos", async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(updated);
+
+    const res = await request(app)
+      .put("/api/conferentes/1")
+      .send({ nome: "Ana Atualizada" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(updated);
+  });
+
+  it("404 quando id nao existe", async () => {
+    (MockedService.prototype.update as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app)
+      .put("/api/conferentes/999")
+      .send({ nome: "Ana Silva" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "N\u00e3o encontrado" });
+  });
+
+  it("500 quando service lanca erro", async () => {
+    (MockedService.prototype.update as jest.Mock).mockRejectedValue(new Error("DB error"));
+
+    const res = await request(app)
+      .put("/api/conferentes/1")
+      .send({ nome: "Ana Silva" });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Erro interno do servidor" });
+  });
+});
+
+describe("DELETE /api/conferentes/:id", () => {
+  it("204 quando removido", async () => {
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(true);
+
+    const res = await request(app).delete("/api/conferentes/1");
+
+    expect(res.status).toBe(204);
+    expect(res.body).toEqual({});
+  });
+
+  it("404 quando id nao existe", async () => {
+    (MockedService.prototype.delete as jest.Mock).mockResolvedValue(false);
+
+    const res = await request(app).delete("/api/conferentes/999");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "N\u00e3o encontrado" });
+  });
+
+  it("500 quando service lanca erro", async () => {
+    (MockedService.prototype.delete as jest.Mock).mockRejectedValue(new Error("DB error"));
+
+    const res = await request(app).delete("/api/conferentes/1");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Erro interno do servidor" });
+  });
+});

--- a/src/front/app/components/ConferenteForm.tsx
+++ b/src/front/app/components/ConferenteForm.tsx
@@ -2,11 +2,82 @@
 
 import { ArrowLeft, Save } from 'lucide-react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useToast } from './Toast';
+
+const API = process.env.NEXT_PUBLIC_API_URL;
 
 export default function ConferenteForm() {
   const { id } = useParams();
+  const router = useRouter();
   const isEdit = !!id;
+  const { toast } = useToast();
+
+  const [nome, setNome] = useState('');
+  const [email, setEmail] = useState('');
+  const [cargo, setCargo] = useState('');
+  const [telefone, setTelefone] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isEdit) return;
+
+    fetch(`${API}/conferentes/${id}`)
+      .then(r => r.json())
+      .then(data => {
+        setNome(data.nome ?? '');
+        setEmail(data.email ?? '');
+        setCargo(data.cargo ?? '');
+        setTelefone(data.telefone ?? '');
+      })
+      .catch(() => setErro('Erro ao carregar conferente'));
+  }, [id, isEdit]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErro(null);
+
+    if (!nome.trim()) {
+      setErro('Nome e obrigatorio');
+      return;
+    }
+    if (!email.trim()) {
+      setErro('Email e obrigatorio');
+      return;
+    }
+
+    setLoading(true);
+    const body = {
+      nome: nome.trim(),
+      email: email.trim(),
+      cargo: cargo.trim() || null,
+      telefone: telefone.trim() || null,
+    };
+
+    try {
+      const url = isEdit ? `${API}/conferentes/${id}` : `${API}/conferentes`;
+      const method = isEdit ? 'PUT' : 'POST';
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? 'Erro ao salvar');
+      }
+
+      toast(isEdit ? 'Conferente atualizado com sucesso' : 'Conferente cadastrado com sucesso', 'success');
+      router.push('/conferentes');
+    } catch (err: unknown) {
+      setErro(err instanceof Error ? err.message : 'Erro ao salvar');
+    } finally {
+      setLoading(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -21,33 +92,64 @@ export default function ConferenteForm() {
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <form className="space-y-6">
+        {erro && <p className="text-red-600 mb-4">{erro}</p>}
+        <form onSubmit={handleSubmit} className="space-y-6">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Informações do Conferente</h2>
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Informacoes do Conferente</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">Nome Completo *</label>
-                <input type="text" placeholder="Ex: Carlos Oliveira" className="w-full px-4 py-2 border border-gray-300 rounded-lg" />
+                <input
+                  type="text"
+                  placeholder="Ex: Carlos Oliveira"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={nome}
+                  onChange={e => setNome(e.target.value)}
+                  required
+                />
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">Email *</label>
-                <input type="email" placeholder="carlos.oliveira@empresa.com" className="w-full px-4 py-2 border border-gray-300 rounded-lg" />
+                <input
+                  type="email"
+                  placeholder="carlos.oliveira@empresa.com"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                  required
+                />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Telefone *</label>
-                <input type="tel" placeholder="(11) 99876-5432" className="w-full px-4 py-2 border border-gray-300 rounded-lg" />
+                <label className="block text-sm font-medium text-gray-700 mb-2">Telefone</label>
+                <input
+                  type="tel"
+                  placeholder="(11) 99876-5432"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={telefone}
+                  onChange={e => setTelefone(e.target.value)}
+                />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Setor *</label>
-                <input type="text" placeholder="Ex: Auditoria" className="w-full px-4 py-2 border border-gray-300 rounded-lg" />
+                <label className="block text-sm font-medium text-gray-700 mb-2">Cargo</label>
+                <input
+                  type="text"
+                  placeholder="Ex: Auditor"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={cargo}
+                  onChange={e => setCargo(e.target.value)}
+                />
               </div>
             </div>
           </div>
 
           <div className="flex gap-4 pt-4 border-t border-gray-200">
-            <button type="submit" className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+            >
               <Save size={20} />
-              {isEdit ? 'Salvar Alterações' : 'Cadastrar Conferente'}
+              {loading ? 'Salvando...' : isEdit ? 'Salvar Alteracoes' : 'Cadastrar Conferente'}
             </button>
             <Link href="/conferentes" className="px-6 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200">Cancelar</Link>
           </div>

--- a/src/front/app/components/ConferentesList.tsx
+++ b/src/front/app/components/ConferentesList.tsx
@@ -1,19 +1,82 @@
+'use client'
+
+import { useEffect, useState } from 'react';
 import { Plus, Search, Edit2, Trash2 } from 'lucide-react';
 import Link from 'next/link';
+import { useToast } from './Toast';
+
+const API = process.env.NEXT_PUBLIC_API_URL;
+
+type Conferente = {
+  id: number;
+  nome: string;
+  email: string;
+  cargo: string | null;
+  telefone: string | null;
+};
 
 export default function ConferentesList() {
-  const conferentes = [
-    { id: 1, nome: 'Carlos Oliveira', email: 'carlos.oliveira@empresa.com', telefone: '(11) 99876-5432', setor: 'Auditoria' },
-    { id: 2, nome: 'Ana Paula', email: 'ana.paula@empresa.com', telefone: '(11) 99876-5433', setor: 'Controle de Qualidade' },
-    { id: 3, nome: 'Roberto Santos', email: 'roberto.santos@empresa.com', telefone: '(11) 99876-5434', setor: 'Patrimônio' },
-  ];
+  const [conferentes, setConferentes] = useState<Conferente[]>([]);
+  const [busca, setBusca] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    fetch(`${API}/conferentes`)
+      .then(r => r.json())
+      .then(setConferentes)
+      .catch(() => setErro('Erro ao carregar conferentes'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleDelete(id: number) {
+    if (!confirm('Confirmar exclusao do conferente?')) return;
+
+    try {
+      const res = await fetch(`${API}/conferentes/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast(data.error ?? 'Erro ao excluir conferente', 'error');
+        return;
+      }
+
+      setConferentes(prev => prev.filter(conferente => conferente.id !== id));
+      toast('Conferente excluido com sucesso', 'success');
+    } catch {
+      toast('Erro ao excluir conferente', 'error');
+    }
+  }
+
+  const filtrados = conferentes.filter(conferente =>
+    conferente.nome.toLowerCase().includes(busca.toLowerCase()) ||
+    conferente.email.toLowerCase().includes(busca.toLowerCase()) ||
+    (conferente.cargo ?? '').toLowerCase().includes(busca.toLowerCase()) ||
+    (conferente.telefone ?? '').toLowerCase().includes(busca.toLowerCase())
+  );
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-gray-500">Carregando...</div>
+      </div>
+    );
+  }
+
+  if (erro) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-red-600">{erro}</div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 mb-2">Conferentes</h1>
-          <p className="text-gray-600">Gerencie os conferentes responsáveis pela verificação</p>
+          <p className="text-gray-600">Gerencie os conferentes responsaveis pela verificacao</p>
         </div>
         <Link href="/conferentes/novo" className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
           <Plus size={20} />
@@ -22,12 +85,15 @@ export default function ConferentesList() {
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-4">
-        <div className="flex gap-4">
-          <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
-            <input type="text" placeholder="Buscar por nome, email, setor..." className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg" />
-          </div>
-          <button className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200">Filtrar</button>
+        <div className="flex-1 relative">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
+          <input
+            type="text"
+            placeholder="Buscar por nome, email, cargo..."
+            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg"
+            value={busca}
+            onChange={e => setBusca(e.target.value)}
+          />
         </div>
       </div>
 
@@ -38,29 +104,40 @@ export default function ConferentesList() {
               <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Nome</th>
               <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Email</th>
               <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Telefone</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Setor</th>
-              <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">Ações</th>
+              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Cargo</th>
+              <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">Acoes</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-200">
-            {conferentes.map((conferente) => (
-              <tr key={conferente.id} className="hover:bg-gray-50">
-                <td className="px-6 py-4 text-sm text-gray-900 font-medium">{conferente.nome}</td>
-                <td className="px-6 py-4 text-sm text-gray-600">{conferente.email}</td>
-                <td className="px-6 py-4 text-sm text-gray-600">{conferente.telefone}</td>
-                <td className="px-6 py-4 text-sm text-gray-600">{conferente.setor}</td>
-                <td className="px-6 py-4">
-                  <div className="flex justify-end gap-2">
-                    <Link href={`/conferentes/editar/${conferente.id}`} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg">
-                      <Edit2 size={18} />
-                    </Link>
-                    <button className="p-2 text-red-600 hover:bg-red-50 rounded-lg">
-                      <Trash2 size={18} />
-                    </button>
-                  </div>
+            {filtrados.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-6 py-8 text-center text-gray-500">
+                  Nenhum conferente encontrado.
                 </td>
               </tr>
-            ))}
+            ) : (
+              filtrados.map((conferente) => (
+                <tr key={conferente.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 text-sm text-gray-900 font-medium">{conferente.nome}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{conferente.email}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{conferente.telefone ?? '-'}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{conferente.cargo ?? '-'}</td>
+                  <td className="px-6 py-4">
+                    <div className="flex justify-end gap-2">
+                      <Link href={`/conferentes/editar/${conferente.id}`} className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg">
+                        <Edit2 size={18} />
+                      </Link>
+                      <button
+                        onClick={() => handleDelete(conferente.id)}
+                        className="p-2 text-red-600 hover:bg-red-50 rounded-lg"
+                      >
+                        <Trash2 size={18} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>

--- a/src/front/app/components/SidebarLayout.tsx
+++ b/src/front/app/components/SidebarLayout.tsx
@@ -27,24 +27,9 @@ const menuItems = [
   { path: "/estados-item", icon: AlertCircle, label: "Estados do Item" },
 ];
 
-const implementedRoutes: string[] = [
-  "/ambientes",
-  "/fornecedores",
-  "/responsaveis",
-  "/tipos-material",
-];
-
-export default function SidebarLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function SidebarLayout({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [showBanner, setShowBanner] = useState(true);
   const pathname = usePathname();
-  const isPrototype = !implementedRoutes.some(
-    (prefix) => pathname === prefix || pathname.startsWith(prefix + "/"),
-  );
 
   return (
     <div className="flex h-screen bg-gray-50">
@@ -93,24 +78,9 @@ export default function SidebarLayout({
           </div>
         </header>
 
-        {showBanner && isPrototype && (
-          <div className="bg-amber-50 border-b border-amber-200 px-6 py-3 flex items-center justify-between gap-4">
-            <div className="flex items-center gap-2 text-amber-800 text-sm">
-              <span className="font-semibold">Protótipo</span>
-              <span>
-                Esta aplicação está em desenvolvimento. As funcionalidades desta
-                página ainda não foram implementadas.
-              </span>
-            </div>
-            <button
-              onClick={() => setShowBanner(false)}
-              className="text-amber-600 hover:text-amber-800 font-medium text-sm shrink-0"
-            >
-              Fechar
-            </button>
-          </div>
-        )}
-        <main className="flex-1 overflow-auto p-6">{children}</main>
+        <main className="flex-1 overflow-auto p-6">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/src/front/app/components/__tests__/ConferentesList.test.tsx
+++ b/src/front/app/components/__tests__/ConferentesList.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConferentesList from '../ConferentesList';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+const mockToast = jest.fn();
+jest.mock('../Toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const conferentes = [
+  { id: 1, nome: 'Carlos Oliveira', email: 'carlos@empresa.com', cargo: 'Auditor', telefone: '11998765432' },
+  { id: 2, nome: 'Ana Costa', email: 'ana@empresa.com', cargo: null, telefone: null },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000/api';
+});
+
+function mockFetch(handler: (url: string, opts?: RequestInit) => { status: number; body: unknown }) {
+  global.fetch = jest.fn(async (url: RequestInfo | URL, opts?: RequestInit) => {
+    const { status, body } = handler(url.toString(), opts);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  }) as typeof fetch;
+}
+
+describe('ConferentesList', () => {
+  it('renderiza lista carregada da API', async () => {
+    mockFetch(() => ({ status: 200, body: conferentes }));
+
+    render(<ConferentesList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Carlos Oliveira')).toBeInTheDocument();
+      expect(screen.getByText('Ana Costa')).toBeInTheDocument();
+    });
+  });
+
+  it('filtra por nome', async () => {
+    mockFetch(() => ({ status: 200, body: conferentes }));
+    render(<ConferentesList />);
+    await waitFor(() => screen.getByText('Carlos Oliveira'));
+
+    await userEvent.type(screen.getByPlaceholderText(/buscar/i), 'ana');
+
+    expect(screen.queryByText('Carlos Oliveira')).not.toBeInTheDocument();
+    expect(screen.getByText('Ana Costa')).toBeInTheDocument();
+  });
+
+  it('filtra por email', async () => {
+    mockFetch(() => ({ status: 200, body: conferentes }));
+    render(<ConferentesList />);
+    await waitFor(() => screen.getByText('Carlos Oliveira'));
+
+    await userEvent.type(screen.getByPlaceholderText(/buscar/i), 'carlos@');
+
+    expect(screen.getByText('Carlos Oliveira')).toBeInTheDocument();
+    expect(screen.queryByText('Ana Costa')).not.toBeInTheDocument();
+  });
+
+  it('filtra por cargo', async () => {
+    mockFetch(() => ({ status: 200, body: conferentes }));
+    render(<ConferentesList />);
+    await waitFor(() => screen.getByText('Carlos Oliveira'));
+
+    await userEvent.type(screen.getByPlaceholderText(/buscar/i), 'auditor');
+
+    expect(screen.getByText('Carlos Oliveira')).toBeInTheDocument();
+    expect(screen.queryByText('Ana Costa')).not.toBeInTheDocument();
+  });
+
+  it('exibe erro ao falhar carregamento', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network'));
+    render(<ConferentesList />);
+    await waitFor(() => expect(screen.getByText(/erro ao carregar/i)).toBeInTheDocument());
+  });
+
+  it('delete com sucesso remove da lista e exibe toast', async () => {
+    mockFetch((_url, opts) => {
+      if (opts?.method === 'DELETE') return { status: 200, body: {} };
+      return { status: 200, body: conferentes };
+    });
+    window.confirm = jest.fn(() => true);
+    render(<ConferentesList />);
+    await waitFor(() => screen.getByText('Carlos Oliveira'));
+
+    const deleteButtons = screen.getAllByRole('button');
+    await userEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Carlos Oliveira')).not.toBeInTheDocument();
+      expect(mockToast).toHaveBeenCalledWith(expect.stringMatching(/sucesso/i), 'success');
+    });
+  });
+
+  it('delete cancelado não chama API', async () => {
+    mockFetch(() => ({ status: 200, body: conferentes }));
+    window.confirm = jest.fn(() => false);
+    render(<ConferentesList />);
+    await waitFor(() => screen.getByText('Carlos Oliveira'));
+
+    const deleteButtons = screen.getAllByRole('button');
+    await userEvent.click(deleteButtons[0]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1); // Only GET
+  });
+
+  it('erro ao excluir exibe toast de erro', async () => {
+    mockFetch((_url, opts) => {
+      if (opts?.method === 'DELETE') return { status: 500, body: { error: 'Erro ao excluir' } };
+      return { status: 200, body: conferentes };
+    });
+    window.confirm = jest.fn(() => true);
+    render(<ConferentesList />);
+    await waitFor(() => screen.getByText('Carlos Oliveira'));
+
+    const deleteButtons = screen.getAllByRole('button');
+    await userEvent.click(deleteButtons[0]);
+
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith(expect.stringMatching(/erro/i), 'error'));
+  });
+});


### PR DESCRIPTION
## O que mudou
- Adicionado CRUD de Conferentes no backend com controller, service, repository e rotas em `/api/conferentes`.
- Integrada a listagem e o formulário de Conferentes ao frontend, substituindo dados fixos por chamadas à API.
- Adicionada busca por nome, email, cargo e telefone.
- Implementados fluxos de criação, edição e exclusão com feedback visual via toast.
- Adicionados testes automatizados para listagem, busca por ID, criação, atualização, exclusão e casos de erro.

## Por quê
- Permitir cadastrar e manter os conferentes responsáveis pelas verificações de patrimônio.
- Conectar a interface ao backend real, evitando manutenção de dados mockados.
- Garantir validação mínima de dados obrigatórios antes de persistir conferentes.

## Como testar
- No backend, executar:
  `npm test -- conferente.test.ts`
- Iniciar backend e frontend com `NEXT_PUBLIC_API_URL` apontando para a API.
- Acessar a tela de Conferentes.
- Criar um conferente preenchendo nome e email.
- Editar o conferente criado e confirmar se os dados são carregados corretamente.
- Buscar por nome, email, cargo ou telefone.
- Excluir um conferente e verificar se ele é removido da listagem.
- Tentar cadastrar conferente sem nome ou sem email e confirmar a validação.

## Auto-review (checklist)
- [ ] Descrição clara (o que/por quê/como testar)
- [ ] PR pequeno e focado
- [ ] Casos limite considerados (ex.: vazio, 0, erro)
- [ ] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
- [Risco] A validação de email verifica presença, mas não formato; pode ser necessário reforçar isso se houver regra de negócio.
- [Manutenção] A branch mantém o padrão controller/service/repository, facilitando evolução futura do CRUD.
- [Teste] Os testes cobrem criação válida, campos obrigatórios, `404` em registros inexistentes e erros internos.
- [Risco] O frontend depende de `NEXT_PUBLIC_API_URL`; ambiente sem essa variável configurada pode quebrar as chamadas.