### PR TITLE
feat: CRUD patrimonio

### DIFF
--- a/src/backend/src/controllers/PatrimonioController.ts
+++ b/src/backend/src/controllers/PatrimonioController.ts
@@ -1,0 +1,110 @@
+import { NextFunction, Request, Response } from "express";
+import { ForeignKeyConstraintError, UniqueConstraintError } from "sequelize";
+import { PatrimonioService } from "../services/PatrimonioService";
+
+const service = new PatrimonioService();
+
+export const PatrimonioController = {
+  async findAll(_req: Request, res: Response) {
+    const items = await service.findAll();
+    res.json(items);
+  },
+
+  async findById(req: Request, res: Response) {
+    const item = await service.findById(Number(req.params.id));
+    if (!item) return res.status(404).json({ error: "Patrimonio nao encontrado" });
+    res.json(item);
+  },
+
+  async create(req: Request, res: Response, next: NextFunction) {
+    const {
+      numero_patrimonio,
+      descricao,
+      valor,
+      tipo_material_id,
+      estado_item_id,
+      ambiente_id,
+      responsavel_id,
+    } = req.body;
+
+    if (!numero_patrimonio || String(numero_patrimonio).trim() === "") {
+      return res.status(400).json({ error: "numero_patrimonio e obrigatorio" });
+    }
+    if (!descricao || String(descricao).trim() === "") {
+      return res.status(400).json({ error: "descricao e obrigatoria" });
+    }
+    if (valor === undefined || valor === null || isNaN(Number(valor)) || Number(valor) < 0) {
+      return res.status(400).json({ error: "valor e obrigatorio e deve ser um numero nao negativo" });
+    }
+    if (!tipo_material_id) {
+      return res.status(400).json({ error: "tipo_material_id e obrigatorio" });
+    }
+    if (!estado_item_id) {
+      return res.status(400).json({ error: "estado_item_id e obrigatorio" });
+    }
+    if (!ambiente_id) {
+      return res.status(400).json({ error: "ambiente_id e obrigatorio" });
+    }
+    if (!responsavel_id) {
+      return res.status(400).json({ error: "responsavel_id e obrigatorio" });
+    }
+
+    try {
+      const item = await service.create(req.body);
+      res.status(201).json(item);
+    } catch (err) {
+      if (err instanceof UniqueConstraintError) {
+        return res.status(409).json({ error: "Ja existe um patrimonio cadastrado com este numero" });
+      }
+      if (err instanceof ForeignKeyConstraintError) {
+        return res.status(400).json({ error: "Referencia invalida: verifique tipo_material, estado_item, ambiente, responsavel ou fornecedor" });
+      }
+      next(err);
+    }
+  },
+
+  async update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const item = await service.update(Number(req.params.id), req.body);
+      if (!item) return res.status(404).json({ error: "Patrimonio nao encontrado" });
+      res.json(item);
+    } catch (err) {
+      if (err instanceof UniqueConstraintError) {
+        return res.status(409).json({ error: "Ja existe um patrimonio cadastrado com este numero" });
+      }
+      if (err instanceof ForeignKeyConstraintError) {
+        return res.status(400).json({ error: "Referencia invalida: verifique tipo_material, estado_item, ambiente, responsavel ou fornecedor" });
+      }
+      next(err);
+    }
+  },
+
+  async listDeletados(_req: Request, res: Response, next: NextFunction) {
+    try {
+      const items = await service.findDeleted();
+      res.json(items);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async restaurar(req: Request, res: Response, next: NextFunction) {
+    try {
+      const item = await service.restore(Number(req.params.id));
+      if (!item) return res.status(404).json({ error: "Patrimonio nao encontrado" });
+      res.json(item);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  async delete(req: Request, res: Response, next: NextFunction) {
+    try {
+      const deleted = await service.delete(Number(req.params.id));
+      if (!deleted) return res.status(404).json({ error: "Patrimonio nao encontrado" });
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+};

--- a/src/backend/src/repositories/PatrimonioRepository.ts
+++ b/src/backend/src/repositories/PatrimonioRepository.ts
@@ -1,0 +1,8 @@
+import { Patrimonio } from '../models/Patrimonio';
+import { BaseRepository } from './BaseRepository';
+
+export class PatrimonioRepository extends BaseRepository<Patrimonio> {
+  constructor() {
+    super(Patrimonio);
+  }
+}

--- a/src/backend/src/routes/index.ts
+++ b/src/backend/src/routes/index.ts
@@ -3,6 +3,7 @@ import ambienteRoutes from "./ambiente.routes";
 import conferenteRoutes from "./conferente.routes";
 import estadoItemRoutes from "./estadoItem.routes";
 import fornecedoresRoutes from "./fornecedores.routes";
+import patrimonioRoutes from "./patrimonio.routes";
 import responsavelRoutes from "./responsavel.routes";
 import tipoMaterialRoutes from "./tipoMaterial.routes";
 
@@ -12,6 +13,7 @@ router.use("/ambientes", ambienteRoutes);
 router.use("/conferentes", conferenteRoutes);
 router.use("/estados-item", estadoItemRoutes);
 router.use("/fornecedores", fornecedoresRoutes);
+router.use("/patrimonios", patrimonioRoutes);
 router.use("/responsaveis", responsavelRoutes);
 router.use("/tipo-material", tipoMaterialRoutes);
 

--- a/src/backend/src/routes/patrimonio.routes.ts
+++ b/src/backend/src/routes/patrimonio.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { PatrimonioController } from "../controllers/PatrimonioController";
+
+const router = Router();
+
+router.get("/", PatrimonioController.findAll);
+router.get("/deletados", PatrimonioController.listDeletados);
+router.patch("/:id/restaurar", PatrimonioController.restaurar);
+router.get("/:id", PatrimonioController.findById);
+router.post("/", PatrimonioController.create);
+router.put("/:id", PatrimonioController.update);
+router.delete("/:id", PatrimonioController.delete);
+
+export default router;

--- a/src/backend/src/services/PatrimonioService.ts
+++ b/src/backend/src/services/PatrimonioService.ts
@@ -1,0 +1,35 @@
+import { CreationAttributes } from 'sequelize';
+import { Patrimonio } from '../models/Patrimonio';
+import { PatrimonioRepository } from '../repositories/PatrimonioRepository';
+
+export class PatrimonioService {
+  private repo = new PatrimonioRepository();
+
+  findAll() {
+    return this.repo.findAll();
+  }
+
+  findById(id: number) {
+    return this.repo.findById(id);
+  }
+
+  create(data: CreationAttributes<Patrimonio>) {
+    return this.repo.create(data);
+  }
+
+  update(id: number, data: Partial<CreationAttributes<Patrimonio>>) {
+    return this.repo.update(id, data);
+  }
+
+  delete(id: number) {
+    return this.repo.delete(id);
+  }
+
+  findDeleted() {
+    return this.repo.findDeleted();
+  }
+
+  restore(id: number) {
+    return this.repo.restore(id);
+  }
+}

--- a/src/backend/tests/patrimonio.test.ts
+++ b/src/backend/tests/patrimonio.test.ts
@@ -1,0 +1,126 @@
+import request from 'supertest';
+import { UniqueConstraintError } from 'sequelize';
+import app from '../src/app';
+import { PatrimonioService } from '../src/services/PatrimonioService';
+
+jest.mock('../src/services/PatrimonioService');
+const MockedService = PatrimonioService as jest.Mocked<typeof PatrimonioService>;
+
+const validBody = {
+  numero_patrimonio: 'PAT-001',
+  descricao: 'Notebook Dell',
+  valor: 3500,
+  tipo_material_id: 1,
+  estado_item_id: 1,
+  ambiente_id: 1,
+  responsavel_id: 1,
+};
+
+describe('Testes Essenciais Patrimonio', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('POST /api/patrimonios', () => {
+    it('Deve criar um patrimonio com dados validos', async () => {
+      const mockResult = { id: 1, ...validBody };
+      (MockedService.prototype.create as jest.Mock).mockResolvedValue(mockResult);
+
+      const res = await request(app).post('/api/patrimonios').send(validBody);
+
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBe(1);
+      expect(MockedService.prototype.create).toHaveBeenCalled();
+    });
+
+    it('Deve retornar 400 se faltar numero_patrimonio', async () => {
+      const { numero_patrimonio, ...semNumero } = validBody;
+      const res = await request(app).post('/api/patrimonios').send(semNumero);
+
+      expect(res.status).toBe(400);
+      expect(MockedService.prototype.create).not.toHaveBeenCalled();
+    });
+
+    it('Deve retornar 400 se valor for negativo', async () => {
+      const res = await request(app)
+        .post('/api/patrimonios')
+        .send({ ...validBody, valor: -10 });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('Deve retornar 400 se faltar foreign keys obrigatorias', async () => {
+      const res = await request(app)
+        .post('/api/patrimonios')
+        .send({ numero_patrimonio: 'PAT-002', descricao: 'Item', valor: 100 });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('Deve retornar 409 se numero_patrimonio ja existir', async () => {
+      (MockedService.prototype.create as jest.Mock).mockRejectedValue(
+        new UniqueConstraintError({})
+      );
+
+      const res = await request(app).post('/api/patrimonios').send(validBody);
+
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe('GET /api/patrimonios', () => {
+    it('Deve listar patrimonios', async () => {
+      (MockedService.prototype.findAll as jest.Mock).mockResolvedValue([{ id: 1, ...validBody }]);
+
+      const res = await request(app).get('/api/patrimonios');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
+  });
+
+  describe('GET /api/patrimonios/:id', () => {
+    it('Deve retornar 404 se nao encontrado', async () => {
+      (MockedService.prototype.findById as jest.Mock).mockResolvedValue(null);
+
+      const res = await request(app).get('/api/patrimonios/99');
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('PUT /api/patrimonios/:id', () => {
+    it('Deve atualizar um patrimonio existente', async () => {
+      (MockedService.prototype.update as jest.Mock).mockResolvedValue({ id: 1, ...validBody, valor: 4000 });
+
+      const res = await request(app).put('/api/patrimonios/1').send({ valor: 4000 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.valor).toBe(4000);
+    });
+
+    it('Deve retornar 404 ao atualizar inexistente', async () => {
+      (MockedService.prototype.update as jest.Mock).mockResolvedValue(null);
+
+      const res = await request(app).put('/api/patrimonios/99').send({ valor: 4000 });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/patrimonios/:id', () => {
+    it('Deve retornar 204 ao excluir com sucesso', async () => {
+      (MockedService.prototype.delete as jest.Mock).mockResolvedValue(true);
+
+      const res = await request(app).delete('/api/patrimonios/1');
+
+      expect(res.status).toBe(204);
+    });
+
+    it('Deve retornar 404 ao excluir inexistente', async () => {
+      (MockedService.prototype.delete as jest.Mock).mockResolvedValue(false);
+
+      const res = await request(app).delete('/api/patrimonios/99');
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/src/front/app/components/PatrimonioForm.tsx
+++ b/src/front/app/components/PatrimonioForm.tsx
@@ -2,11 +2,127 @@
 
 import { ArrowLeft, Save } from 'lucide-react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { API_URL } from '../lib/api';
+
+type Opcao = { id: number; nome: string };
 
 export default function PatrimonioForm() {
   const { id } = useParams();
+  const router = useRouter();
   const isEdit = !!id;
+
+  const [numeroPatrimonio, setNumeroPatrimonio] = useState('');
+  const [descricao, setDescricao] = useState('');
+  const [valor, setValor] = useState('');
+  const [observacoes, setObservacoes] = useState('');
+  const [tipoMaterialId, setTipoMaterialId] = useState('');
+  const [estadoItemId, setEstadoItemId] = useState('');
+  const [ambienteId, setAmbienteId] = useState('');
+  const [responsavelId, setResponsavelId] = useState('');
+  const [fornecedorId, setFornecedorId] = useState('');
+
+  const [tiposMaterial, setTiposMaterial] = useState<Opcao[]>([]);
+  const [estadosItem, setEstadosItem] = useState<Opcao[]>([]);
+  const [ambientes, setAmbientes] = useState<Opcao[]>([]);
+  const [responsaveis, setResponsaveis] = useState<Opcao[]>([]);
+  const [fornecedores, setFornecedores] = useState<Opcao[]>([]);
+
+  const [loading, setLoading] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/tipo-material`).then(r => r.json()).then(setTiposMaterial).catch(() => {});
+    fetch(`${API_URL}/estados-item`).then(r => r.json()).then(setEstadosItem).catch(() => {});
+    fetch(`${API_URL}/ambientes`).then(r => r.json()).then(setAmbientes).catch(() => {});
+    fetch(`${API_URL}/responsaveis`).then(r => r.json()).then(setResponsaveis).catch(() => {});
+    fetch(`${API_URL}/fornecedores`).then(r => r.json()).then(setFornecedores).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!isEdit) return;
+    fetch(`${API_URL}/patrimonios/${id}`)
+      .then(r => r.json())
+      .then(data => {
+        setNumeroPatrimonio(data.numero_patrimonio ?? '');
+        setDescricao(data.descricao ?? '');
+        setValor(data.valor != null ? String(data.valor) : '');
+        setObservacoes(data.observacoes ?? '');
+        setTipoMaterialId(data.tipo_material_id ? String(data.tipo_material_id) : '');
+        setEstadoItemId(data.estado_item_id ? String(data.estado_item_id) : '');
+        setAmbienteId(data.ambiente_id ? String(data.ambiente_id) : '');
+        setResponsavelId(data.responsavel_id ? String(data.responsavel_id) : '');
+        setFornecedorId(data.fornecedor_id ? String(data.fornecedor_id) : '');
+      })
+      .catch(() => setErro('Erro ao carregar patrimonio'));
+  }, [id, isEdit]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErro(null);
+
+    if (!numeroPatrimonio.trim()) {
+      setErro('Numero do patrimonio e obrigatorio');
+      return;
+    }
+    if (!descricao.trim()) {
+      setErro('Descricao e obrigatoria');
+      return;
+    }
+    if (valor.trim() === '' || isNaN(Number(valor)) || Number(valor) < 0) {
+      setErro('Valor e obrigatorio e deve ser um numero nao negativo');
+      return;
+    }
+    if (!tipoMaterialId) {
+      setErro('Tipo de material e obrigatorio');
+      return;
+    }
+    if (!estadoItemId) {
+      setErro('Estado do item e obrigatorio');
+      return;
+    }
+    if (!ambienteId) {
+      setErro('Ambiente e obrigatorio');
+      return;
+    }
+    if (!responsavelId) {
+      setErro('Responsavel e obrigatorio');
+      return;
+    }
+
+    setLoading(true);
+    const body = {
+      numero_patrimonio: numeroPatrimonio.trim(),
+      descricao: descricao.trim(),
+      valor: Number(valor),
+      observacoes: observacoes.trim() || null,
+      tipo_material_id: Number(tipoMaterialId),
+      estado_item_id: Number(estadoItemId),
+      ambiente_id: Number(ambienteId),
+      responsavel_id: Number(responsavelId),
+      fornecedor_id: fornecedorId ? Number(fornecedorId) : null,
+    };
+
+    try {
+      const url = isEdit ? `${API_URL}/patrimonios/${id}` : `${API_URL}/patrimonios`;
+      const method = isEdit ? 'PUT' : 'POST';
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? 'Erro ao salvar');
+      }
+      router.push('/patrimonios');
+    } catch (err: unknown) {
+      setErro(err instanceof Error ? err.message : 'Erro ao salvar');
+    } finally {
+      setLoading(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -23,7 +139,8 @@ export default function PatrimonioForm() {
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <form className="space-y-6">
+        {erro && <p className="text-red-600 mb-4">{erro}</p>}
+        <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <h2 className="text-lg font-semibold text-gray-900 mb-4">Informações Básicas</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -35,17 +152,25 @@ export default function PatrimonioForm() {
                   type="text"
                   placeholder="Ex: 1234"
                   className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={numeroPatrimonio}
+                  onChange={e => setNumeroPatrimonio(e.target.value)}
+                  required
                 />
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Tipo de Material *
                 </label>
-                <select className="w-full px-4 py-2 border border-gray-300 rounded-lg">
+                <select
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={tipoMaterialId}
+                  onChange={e => setTipoMaterialId(e.target.value)}
+                  required
+                >
                   <option value="">Selecione...</option>
-                  <option value="informatica">Informática</option>
-                  <option value="mobiliario">Mobiliário</option>
-                  <option value="eletronicos">Eletrônicos</option>
+                  {tiposMaterial.map(t => (
+                    <option key={t.id} value={t.id}>{t.nome}</option>
+                  ))}
                 </select>
               </div>
               <div className="md:col-span-2">
@@ -56,33 +181,61 @@ export default function PatrimonioForm() {
                   type="text"
                   placeholder="Ex: Notebook Dell Latitude 5420"
                   className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={descricao}
+                  onChange={e => setDescricao(e.target.value)}
+                  required
                 />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Valor (R$) *
+                </label>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  placeholder="Ex: 3500.00"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={valor}
+                  onChange={e => setValor(e.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Estado do Item *
+                </label>
+                <select
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={estadoItemId}
+                  onChange={e => setEstadoItemId(e.target.value)}
+                  required
+                >
+                  <option value="">Selecione...</option>
+                  {estadosItem.map(es => (
+                    <option key={es.id} value={es.id}>{es.nome}</option>
+                  ))}
+                </select>
               </div>
             </div>
           </div>
 
           <div>
             <h2 className="text-lg font-semibold text-gray-900 mb-4">Fornecedor</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Fornecedor *
-                </label>
-                <select className="w-full px-4 py-2 border border-gray-300 rounded-lg">
-                  <option value="">Selecione...</option>
-                  <option value="fornecedor1">Fornecedor A</option>
-                  <option value="fornecedor2">Fornecedor B</option>
-                </select>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Data de Aquisição
-                </label>
-                <input
-                  type="date"
-                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
-                />
-              </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Fornecedor
+              </label>
+              <select
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                value={fornecedorId}
+                onChange={e => setFornecedorId(e.target.value)}
+              >
+                <option value="">Selecione...</option>
+                {fornecedores.map(f => (
+                  <option key={f.id} value={f.id}>{f.nome}</option>
+                ))}
+              </select>
             </div>
           </div>
 
@@ -93,26 +246,33 @@ export default function PatrimonioForm() {
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Ambiente *
                 </label>
-                <select className="w-full px-4 py-2 border border-gray-300 rounded-lg">
+                <select
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={ambienteId}
+                  onChange={e => setAmbienteId(e.target.value)}
+                  required
+                >
                   <option value="">Selecione...</option>
-                  <option value="sala201">Sala 201</option>
-                  <option value="sala305">Sala 305</option>
-                  <option value="lab3">Laboratório 3</option>
+                  {ambientes.map(a => (
+                    <option key={a.id} value={a.id}>{a.nome}</option>
+                  ))}
                 </select>
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Responsável *
                 </label>
-                <select className="w-full px-4 py-2 border border-gray-300 rounded-lg">
+                <select
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                  value={responsavelId}
+                  onChange={e => setResponsavelId(e.target.value)}
+                  required
+                >
                   <option value="">Selecione...</option>
-                  <option value="joao">João Silva</option>
-                  <option value="maria">Maria Santos</option>
-                  <option value="pedro">Pedro Costa</option>
+                  {responsaveis.map(r => (
+                    <option key={r.id} value={r.id}>{r.nome}</option>
+                  ))}
                 </select>
-                <p className="text-sm text-gray-500 mt-1">
-                  O responsável é vinculado ao ambiente selecionado
-                </p>
               </div>
             </div>
           </div>
@@ -127,6 +287,8 @@ export default function PatrimonioForm() {
                 rows={4}
                 placeholder="Informações adicionais sobre o patrimônio..."
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg"
+                value={observacoes}
+                onChange={e => setObservacoes(e.target.value)}
               ></textarea>
             </div>
           </div>
@@ -134,10 +296,11 @@ export default function PatrimonioForm() {
           <div className="flex gap-4 pt-4 border-t border-gray-200">
             <button
               type="submit"
-              className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+              disabled={loading}
+              className="flex items-center gap-2 px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
             >
               <Save size={20} />
-              {isEdit ? 'Salvar Alterações' : 'Cadastrar Patrimônio'}
+              {loading ? 'Salvando...' : isEdit ? 'Salvar Alterações' : 'Cadastrar Patrimônio'}
             </button>
             <Link
               href="/patrimonios"

--- a/src/front/app/components/PatrimoniosList.tsx
+++ b/src/front/app/components/PatrimoniosList.tsx
@@ -1,13 +1,85 @@
+'use client'
+
+import { useEffect, useState } from 'react';
 import { Plus, Search, Edit2, Trash2, AlertCircle } from 'lucide-react';
+import { useToast } from './Toast';
 import Link from 'next/link';
+import { API_URL } from '../lib/api';
+
+type Patrimonio = {
+  id: number;
+  numero_patrimonio: string;
+  descricao: string;
+  valor: number;
+  tipo_material_id: number;
+  estado_item_id: number;
+  ambiente_id: number;
+  responsavel_id: number;
+  fornecedor_id: number | null;
+};
+
+type Opcao = { id: number; nome: string };
+
+function mapaNomes(lista: Opcao[]): Record<number, string> {
+  return Object.fromEntries(lista.map(o => [o.id, o.nome]));
+}
 
 export default function PatrimoniosList() {
-  const patrimonios = [
-    { id: 1, numero: '1234', descricao: 'Notebook Dell Latitude', tipo: 'Informática', ambiente: 'Sala 201', responsavel: 'João Silva', estado: 'Ativo', estadoColor: 'text-green-600 bg-green-50' },
-    { id: 2, numero: '5678', descricao: 'Cadeira Ergonômica', tipo: 'Mobiliário', ambiente: 'Sala 305', responsavel: 'Maria Santos', estado: 'Em Manutenção', estadoColor: 'text-orange-600 bg-orange-50' },
-    { id: 3, numero: '9012', descricao: 'Projetor Epson', tipo: 'Eletrônicos', ambiente: 'Lab. 3', responsavel: 'Pedro Costa', estado: 'Ativo', estadoColor: 'text-green-600 bg-green-50' },
-    { id: 4, numero: '3456', descricao: 'Mesa de Escritório', tipo: 'Mobiliário', ambiente: 'Sala 201', responsavel: 'João Silva', estado: 'Avariado', estadoColor: 'text-red-600 bg-red-50' },
-  ];
+  const [patrimonios, setPatrimonios] = useState<Patrimonio[]>([]);
+  const [tipos, setTipos] = useState<Record<number, string>>({});
+  const [ambientes, setAmbientes] = useState<Record<number, string>>({});
+  const [responsaveis, setResponsaveis] = useState<Record<number, string>>({});
+  const [estados, setEstados] = useState<Record<number, string>>({});
+  const [busca, setBusca] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    Promise.all([
+      fetch(`${API_URL}/patrimonios`).then(r => r.json()),
+      fetch(`${API_URL}/tipo-material`).then(r => r.json()),
+      fetch(`${API_URL}/ambientes`).then(r => r.json()),
+      fetch(`${API_URL}/responsaveis`).then(r => r.json()),
+      fetch(`${API_URL}/estados-item`).then(r => r.json()),
+    ])
+      .then(([pats, tps, ambs, resps, ests]) => {
+        setPatrimonios(pats);
+        setTipos(mapaNomes(tps));
+        setAmbientes(mapaNomes(ambs));
+        setResponsaveis(mapaNomes(resps));
+        setEstados(mapaNomes(ests));
+      })
+      .catch(() => setErro('Erro ao carregar patrimonios'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleDelete(id: number) {
+    if (!confirm('Confirmar exclusao do patrimonio?')) return;
+
+    try {
+      const res = await fetch(`${API_URL}/patrimonios/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast(data.error ?? 'Erro ao excluir patrimonio', 'error');
+        return;
+      }
+      setPatrimonios(prev => prev.filter(p => p.id !== id));
+      toast('Patrimonio excluido com sucesso', 'success');
+    } catch {
+      toast('Erro ao excluir patrimonio', 'error');
+    }
+  }
+
+  const filtrados = patrimonios.filter(p => {
+    const termo = busca.toLowerCase();
+    return (
+      p.numero_patrimonio.toLowerCase().includes(termo) ||
+      p.descricao.toLowerCase().includes(termo) ||
+      (ambientes[p.ambiente_id] ?? '').toLowerCase().includes(termo) ||
+      (responsaveis[p.responsavel_id] ?? '').toLowerCase().includes(termo)
+    );
+  });
 
   return (
     <div className="space-y-6">
@@ -26,72 +98,84 @@ export default function PatrimoniosList() {
       </div>
 
       <div className="bg-white border border-gray-200 rounded-lg p-4">
-        <div className="flex gap-4">
-          <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
-            <input
-              type="text"
-              placeholder="Buscar por número, descrição, ambiente..."
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg"
-            />
-          </div>
-          <button className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200">
-            Filtrar
-          </button>
+        <div className="flex-1 relative">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={20} />
+          <input
+            type="text"
+            placeholder="Buscar por número, descrição, ambiente ou responsável..."
+            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg"
+            value={busca}
+            onChange={e => setBusca(e.target.value)}
+          />
         </div>
       </div>
 
-      <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-        <table className="w-full">
-          <thead className="bg-gray-50 border-b border-gray-200">
-            <tr>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Número</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Descrição</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Tipo</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Ambiente</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Responsável</th>
-              <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Estado</th>
-              <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">Ações</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200">
-            {patrimonios.map((patrimonio) => (
-              <tr key={patrimonio.id} className="hover:bg-gray-50">
-                <td className="px-6 py-4 text-sm text-gray-900">#{patrimonio.numero}</td>
-                <td className="px-6 py-4 text-sm text-gray-900">{patrimonio.descricao}</td>
-                <td className="px-6 py-4 text-sm text-gray-600">{patrimonio.tipo}</td>
-                <td className="px-6 py-4 text-sm text-gray-600">{patrimonio.ambiente}</td>
-                <td className="px-6 py-4 text-sm text-gray-600">{patrimonio.responsavel}</td>
-                <td className="px-6 py-4">
-                  <span className={`inline-flex px-2 py-1 text-xs rounded-full ${patrimonio.estadoColor}`}>
-                    {patrimonio.estado}
-                  </span>
-                </td>
-                <td className="px-6 py-4">
-                  <div className="flex justify-end gap-2">
-                    <Link
-                      href={`/patrimonios/estado/${patrimonio.id}`}
-                      className="p-2 text-orange-600 hover:bg-orange-50 rounded-lg"
-                      title="Registrar Estado"
-                    >
-                      <AlertCircle size={18} />
-                    </Link>
-                    <Link
-                      href={`/patrimonios/editar/${patrimonio.id}`}
-                      className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg"
-                    >
-                      <Edit2 size={18} />
-                    </Link>
-                    <button className="p-2 text-red-600 hover:bg-red-50 rounded-lg">
-                      <Trash2 size={18} />
-                    </button>
-                  </div>
-                </td>
+      {erro && <p className="text-red-600">{erro}</p>}
+      {loading && <p className="text-gray-500">Carregando...</p>}
+
+      {!loading && !erro && (
+        <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+          <table className="w-full">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Número</th>
+                <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Descrição</th>
+                <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Tipo</th>
+                <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Ambiente</th>
+                <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Responsável</th>
+                <th className="px-6 py-3 text-left text-sm font-semibold text-gray-900">Estado</th>
+                <th className="px-6 py-3 text-right text-sm font-semibold text-gray-900">Ações</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {filtrados.map((patrimonio) => (
+                <tr key={patrimonio.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 text-sm text-gray-900">#{patrimonio.numero_patrimonio}</td>
+                  <td className="px-6 py-4 text-sm text-gray-900">{patrimonio.descricao}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{tipos[patrimonio.tipo_material_id] ?? '-'}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{ambientes[patrimonio.ambiente_id] ?? '-'}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{responsaveis[patrimonio.responsavel_id] ?? '-'}</td>
+                  <td className="px-6 py-4">
+                    <span className="inline-flex px-2 py-1 text-xs rounded-full text-gray-600 bg-gray-100">
+                      {estados[patrimonio.estado_item_id] ?? '-'}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4">
+                    <div className="flex justify-end gap-2">
+                      <Link
+                        href={`/patrimonios/estado/${patrimonio.id}`}
+                        className="p-2 text-orange-600 hover:bg-orange-50 rounded-lg"
+                        title="Registrar Estado"
+                      >
+                        <AlertCircle size={18} />
+                      </Link>
+                      <Link
+                        href={`/patrimonios/editar/${patrimonio.id}`}
+                        className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg"
+                      >
+                        <Edit2 size={18} />
+                      </Link>
+                      <button
+                        onClick={() => handleDelete(patrimonio.id)}
+                        className="p-2 text-red-600 hover:bg-red-50 rounded-lg"
+                      >
+                        <Trash2 size={18} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {filtrados.length === 0 && (
+                <tr>
+                  <td colSpan={7} className="px-6 py-8 text-center text-gray-500">
+                    Nenhum patrimônio encontrado.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/front/app/components/__tests__/PatrimoniosList.test.tsx
+++ b/src/front/app/components/__tests__/PatrimoniosList.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PatrimoniosList from "../PatrimoniosList";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockToast = jest.fn();
+jest.mock("../Toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const patrimonios = [
+  {
+    id: 1,
+    numero_patrimonio: "1234",
+    descricao: "Notebook Dell",
+    valor: 3500,
+    tipo_material_id: 1,
+    estado_item_id: 1,
+    ambiente_id: 1,
+    responsavel_id: 1,
+    fornecedor_id: null,
+  },
+  {
+    id: 2,
+    numero_patrimonio: "5678",
+    descricao: "Cadeira Ergonomica",
+    valor: 800,
+    tipo_material_id: 2,
+    estado_item_id: 2,
+    ambiente_id: 2,
+    responsavel_id: 2,
+    fornecedor_id: null,
+  },
+];
+
+const tipos = [{ id: 1, nome: "Informatica" }, { id: 2, nome: "Mobiliario" }];
+const ambientes = [{ id: 1, nome: "Sala 201" }, { id: 2, nome: "Sala 305" }];
+const responsaveis = [{ id: 1, nome: "Joao Silva" }, { id: 2, nome: "Maria Santos" }];
+const estados = [{ id: 1, nome: "Ativo" }, { id: 2, nome: "Em Manutencao" }];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_API_URL = "http://localhost:8000/api";
+});
+
+function routeBody(url: string) {
+  if (url.includes("/patrimonios")) return patrimonios;
+  if (url.includes("/tipo-material")) return tipos;
+  if (url.includes("/ambientes")) return ambientes;
+  if (url.includes("/responsaveis")) return responsaveis;
+  if (url.includes("/estados-item")) return estados;
+  return [];
+}
+
+function mockFetch(
+  handler: (url: string, opts?: RequestInit) => { status: number; body: unknown },
+) {
+  global.fetch = jest.fn(async (url: RequestInfo | URL, opts?: RequestInit) => {
+    const { status, body } = handler(url.toString(), opts);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  }) as typeof fetch;
+}
+
+describe("PatrimoniosList", () => {
+  it("renderiza lista carregada da API com nomes resolvidos das FKs", async () => {
+    mockFetch((url) => ({ status: 200, body: routeBody(url) }));
+
+    render(<PatrimoniosList />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Notebook Dell")).toBeInTheDocument();
+      expect(screen.getByText("Cadeira Ergonomica")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Informatica")).toBeInTheDocument();
+    expect(screen.getByText("Sala 201")).toBeInTheDocument();
+    expect(screen.getByText("Joao Silva")).toBeInTheDocument();
+    expect(screen.getByText("Ativo")).toBeInTheDocument();
+  });
+
+  it("filtra por descricao, ambiente e responsavel", async () => {
+    mockFetch((url) => ({ status: 200, body: routeBody(url) }));
+    render(<PatrimoniosList />);
+    await waitFor(() => screen.getByText("Notebook Dell"));
+
+    await userEvent.type(screen.getByPlaceholderText(/buscar/i), "Maria");
+
+    expect(screen.queryByText("Notebook Dell")).not.toBeInTheDocument();
+    expect(screen.getByText("Cadeira Ergonomica")).toBeInTheDocument();
+  });
+
+  it("renderiza links de cadastro, edicao e estado", async () => {
+    mockFetch((url) => ({ status: 200, body: routeBody(url) }));
+    render(<PatrimoniosList />);
+    await waitFor(() => screen.getByText("Notebook Dell"));
+
+    expect(screen.getByRole("link", { name: /novo patrimônio/i })).toHaveAttribute(
+      "href",
+      "/patrimonios/novo",
+    );
+    const hrefs = screen.getAllByRole("link").map((l) => l.getAttribute("href"));
+    expect(hrefs).toContain("/patrimonios/editar/1");
+    expect(hrefs).toContain("/patrimonios/estado/1");
+  });
+
+  it("exibe erro ao falhar carregamento", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network"));
+
+    render(<PatrimoniosList />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/erro ao carregar patrimonios/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("delete com sucesso remove da lista e exibe toast", async () => {
+    mockFetch((url, opts) => {
+      if (opts?.method === "DELETE") return { status: 204, body: null };
+      return { status: 200, body: routeBody(url) };
+    });
+    window.confirm = jest.fn(() => true);
+    render(<PatrimoniosList />);
+    await waitFor(() => screen.getByText("Notebook Dell"));
+
+    await userEvent.click(screen.getAllByRole("button")[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Notebook Dell")).not.toBeInTheDocument();
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.stringMatching(/sucesso/i),
+        "success",
+      );
+    });
+  });
+
+  it("delete cancelado nao chama API de delete", async () => {
+    mockFetch((url) => ({ status: 200, body: routeBody(url) }));
+    window.confirm = jest.fn(() => false);
+    render(<PatrimoniosList />);
+    await waitFor(() => screen.getByText("Notebook Dell"));
+    const chamadasIniciais = (global.fetch as jest.Mock).mock.calls.length;
+
+    await userEvent.click(screen.getAllByRole("button")[0]);
+
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(chamadasIniciais);
+  });
+
+  it("exibe mensagem quando lista esta vazia", async () => {
+    mockFetch((url) => {
+      if (url.includes("/patrimonios")) return { status: 200, body: [] };
+      return { status: 200, body: routeBody(url) };
+    });
+
+    render(<PatrimoniosList />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/nenhum patrimônio encontrado/i)).toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## O que mudou
- CRUD de patrimônio no backend (rota `/api/patrimonios`).
- Telas de patrimônio no front ligadas à API (antes mockadas).
- Testes do endpoint e da listagem.

## Por quê
- Fecha o issue de cadastro de patrimônio.
- Era o único CRUD com front ainda mockado.

## Como testar
- Backend: `cd src/backend && npm test`
- Frontend: `cd src/front && npm test`

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
- [Teste] Endpoint e lista do front cobertos por teste de unidade.
- [Manutenção] Mesmo padrão das outras entidades (Repository/Service/Controller).
