### PR TITLE
Dashboard com dados reais

### DIFF
--- a/src/front/app/components/Dashboard.tsx
+++ b/src/front/app/components/Dashboard.tsx
@@ -1,19 +1,139 @@
+'use client'
+
+import { useEffect, useState } from 'react';
 import { Package, MapPin, Users, AlertTriangle } from 'lucide-react';
+import { API_URL } from '../lib/api';
+
+type Patrimonio = {
+  id: number;
+  numero_patrimonio: string;
+  descricao: string;
+  estado_item_id: number;
+};
+
+type Opcao = { id: number; nome: string };
+
+type AuditLog = {
+  id: number;
+  tabela: string;
+  registro_id: number;
+  acao: string;
+  dados_novos: Record<string, unknown> | null;
+  created_at: string;
+};
+
+type AuditLogResponse = {
+  data: AuditLog[];
+};
+
+function normalizar(texto: string) {
+  return texto.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+}
+
+function formatarData(valor: string) {
+  return new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(valor));
+}
+
+function labelTabela(tabela: string) {
+  const labels: Record<string, string> = {
+    ambiente: 'Ambiente',
+    conferente: 'Conferente',
+    estado_item: 'Estado do item',
+    fornecedor: 'Fornecedor',
+    patrimonio: 'Patrimônio',
+    responsavel: 'Responsável',
+    tipo_material: 'Tipo de material',
+  };
+
+  return labels[tabela] ?? tabela;
+}
+
+function labelAcao(acao: string) {
+  const labels: Record<string, string> = {
+    CREATE: 'cadastrado',
+    UPDATE: 'atualizado',
+    DELETE: 'removido',
+    RESTORE: 'restaurado',
+  };
+
+  return labels[acao.toUpperCase()] ?? acao.toLowerCase();
+}
+
+function descricaoRegistro(log: AuditLog) {
+  const dados = log.dados_novos ?? {};
+  const nome = dados.nome ?? dados.descricao ?? dados.numero_patrimonio;
+
+  if (typeof nome === 'string' && nome.trim()) {
+    return `"${nome}"`;
+  }
+
+  return `#${log.registro_id}`;
+}
+
+function descricaoAtividade(log: AuditLog) {
+  return `${labelTabela(log.tabela)} ${descricaoRegistro(log)} ${labelAcao(log.acao)}`;
+}
+
+async function buscarJson<T>(url: string): Promise<T> {
+  const resposta = await fetch(url);
+
+  if (!resposta.ok) {
+    throw new Error('Erro ao carregar dados do dashboard');
+  }
+
+  return resposta.json();
+}
 
 export default function Dashboard() {
-  const stats = [
-    { label: 'Total de Patrimônios', value: '248', icon: Package, color: 'bg-blue-50 text-blue-600' },
-    { label: 'Ambientes Cadastrados', value: '42', icon: MapPin, color: 'bg-green-50 text-green-600' },
-    { label: 'Responsáveis Ativos', value: '28', icon: Users, color: 'bg-purple-50 text-purple-600' },
-    { label: 'Itens em Manutenção', value: '12', icon: AlertTriangle, color: 'bg-orange-50 text-orange-600' },
-  ];
+  const [patrimonios, setPatrimonios] = useState<Patrimonio[]>([]);
+  const [ambientes, setAmbientes] = useState<Opcao[]>([]);
+  const [responsaveis, setResponsaveis] = useState<Opcao[]>([]);
+  const [estados, setEstados] = useState<Opcao[]>([]);
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState<string | null>(null);
 
-  const recentActivities = [
-    { id: 1, action: 'Patrimônio #1234 cadastrado', date: '29/04/2026 10:30' },
-    { id: 2, action: 'Ambiente "Sala 201" atualizado', date: '29/04/2026 09:15' },
-    { id: 3, action: 'Manutenção solicitada para #5678', date: '28/04/2026 16:45' },
-    { id: 4, action: 'Responsável "João Silva" cadastrado', date: '28/04/2026 14:20' },
-    { id: 5, action: 'Patrimônio #9012 alocado para "Lab. 3"', date: '27/04/2026 11:00' },
+  useEffect(() => {
+    Promise.all([
+      buscarJson<Patrimonio[]>(`${API_URL}/patrimonios`),
+      buscarJson<Opcao[]>(`${API_URL}/ambientes`),
+      buscarJson<Opcao[]>(`${API_URL}/responsaveis`),
+      buscarJson<Opcao[]>(`${API_URL}/estados-item`),
+      buscarJson<AuditLogResponse>(`${API_URL}/audit-log?limit=5`),
+    ])
+      .then(([pats, ambs, resps, ests, auditLogs]) => {
+        setPatrimonios(pats);
+        setAmbientes(ambs);
+        setResponsaveis(resps);
+        setEstados(ests);
+        setLogs(auditLogs.data ?? []);
+      })
+      .catch(() => setErro('Erro ao carregar dados do dashboard'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const estadosManutencao = new Set(
+    estados
+      .filter((estado) => normalizar(estado.nome).includes('manutencao'))
+      .map((estado) => estado.id),
+  );
+
+  const stats = [
+    { label: 'Total de Patrimônios', value: patrimonios.length, icon: Package, color: 'bg-blue-50 text-blue-600' },
+    { label: 'Ambientes Cadastrados', value: ambientes.length, icon: MapPin, color: 'bg-green-50 text-green-600' },
+    { label: 'Responsáveis Ativos', value: responsaveis.length, icon: Users, color: 'bg-purple-50 text-purple-600' },
+    {
+      label: 'Itens em Manutenção',
+      value: patrimonios.filter((patrimonio) => estadosManutencao.has(patrimonio.estado_item_id)).length,
+      icon: AlertTriangle,
+      color: 'bg-orange-50 text-orange-600',
+    },
   ];
 
   return (
@@ -23,38 +143,50 @@ export default function Dashboard() {
         <p className="text-gray-600">Visão geral do sistema de gestão patrimonial</p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        {stats.map((stat) => {
-          const Icon = stat.icon;
-          return (
-            <div key={stat.label} className="bg-white border border-gray-200 rounded-lg p-6">
-              <div className="flex items-center justify-between mb-4">
-                <div className={`p-3 rounded-lg ${stat.color}`}>
-                  <Icon size={24} />
-                </div>
-              </div>
-              <p className="text-3xl font-bold text-gray-900 mb-1">{stat.value}</p>
-              <p className="text-sm text-gray-600">{stat.label}</p>
-            </div>
-          );
-        })}
-      </div>
+      {erro && <p className="text-red-600">{erro}</p>}
+      {loading && <p className="text-gray-500">Carregando...</p>}
 
-      <div className="bg-white border border-gray-200 rounded-lg">
-        <div className="p-6 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Atividades Recentes</h2>
-        </div>
-        <div className="divide-y divide-gray-200">
-          {recentActivities.map((activity) => (
-            <div key={activity.id} className="p-4 hover:bg-gray-50">
-              <div className="flex justify-between items-start">
-                <p className="text-gray-900">{activity.action}</p>
-                <span className="text-sm text-gray-500">{activity.date}</span>
-              </div>
+      {!loading && !erro && (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            {stats.map((stat) => {
+              const Icon = stat.icon;
+              return (
+                <div key={stat.label} className="bg-white border border-gray-200 rounded-lg p-6">
+                  <div className="flex items-center justify-between mb-4">
+                    <div className={`p-3 rounded-lg ${stat.color}`}>
+                      <Icon size={24} />
+                    </div>
+                  </div>
+                  <p className="text-3xl font-bold text-gray-900 mb-1">{stat.value}</p>
+                  <p className="text-sm text-gray-600">{stat.label}</p>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="bg-white border border-gray-200 rounded-lg">
+            <div className="p-6 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">Atividades Recentes</h2>
             </div>
-          ))}
-        </div>
-      </div>
+            <div className="divide-y divide-gray-200">
+              {logs.map((activity) => (
+                <div key={activity.id} className="p-4 hover:bg-gray-50">
+                  <div className="flex justify-between items-start gap-4">
+                    <p className="text-gray-900">{descricaoAtividade(activity)}</p>
+                    <span className="text-sm text-gray-500 whitespace-nowrap">{formatarData(activity.created_at)}</span>
+                  </div>
+                </div>
+              ))}
+              {logs.length === 0 && (
+                <div className="p-4 text-gray-500">
+                  Nenhuma atividade recente encontrada.
+                </div>
+              )}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/front/app/components/__tests__/Dashboard.test.tsx
+++ b/src/front/app/components/__tests__/Dashboard.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import Dashboard from "../Dashboard";
+
+const patrimonios = [
+  {
+    id: 1,
+    numero_patrimonio: "1234",
+    descricao: "Notebook Dell",
+    estado_item_id: 1,
+  },
+  {
+    id: 2,
+    numero_patrimonio: "5678",
+    descricao: "Cadeira Ergonomica",
+    estado_item_id: 2,
+  },
+  {
+    id: 3,
+    numero_patrimonio: "9012",
+    descricao: "Monitor LG",
+    estado_item_id: 2,
+  },
+];
+
+const ambientes = [{ id: 1, nome: "Sala 201" }, { id: 2, nome: "Laboratorio 3" }];
+const responsaveis = [{ id: 1, nome: "Joao Silva" }, { id: 2, nome: "Maria Santos" }];
+const estados = [{ id: 1, nome: "Ativo" }, { id: 2, nome: "Em Manutencao" }];
+const auditLog = {
+  total: 1,
+  pages: 1,
+  currentPage: 1,
+  limit: 5,
+  data: [
+    {
+      id: 10,
+      tabela: "patrimonio",
+      registro_id: 1,
+      acao: "CREATE",
+      dados_novos: { numero_patrimonio: "1234" },
+      created_at: "2026-04-29T13:30:00.000Z",
+    },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NEXT_PUBLIC_API_URL = "http://localhost:8000/api";
+});
+
+function routeBody(url: string) {
+  if (url.includes("/patrimonios")) return patrimonios;
+  if (url.includes("/ambientes")) return ambientes;
+  if (url.includes("/responsaveis")) return responsaveis;
+  if (url.includes("/estados-item")) return estados;
+  if (url.includes("/audit-log")) return auditLog;
+  return [];
+}
+
+function mockFetch(
+  handler: (url: string) => { status: number; body: unknown },
+) {
+  global.fetch = jest.fn(async (url: RequestInfo | URL) => {
+    const { status, body } = handler(url.toString());
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  }) as typeof fetch;
+}
+
+function expectStat(label: string, value: string) {
+  const card = screen.getByText(label).closest("div");
+  expect(card).not.toBeNull();
+  expect(within(card as HTMLElement).getByText(value)).toBeInTheDocument();
+}
+
+describe("Dashboard", () => {
+  it("renderiza os cards com dados reais retornados pela API", async () => {
+    mockFetch((url) => ({ status: 200, body: routeBody(url) }));
+
+    render(<Dashboard />);
+
+    expect(screen.getByText(/carregando/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expectStat("Total de Patrimônios", "3");
+      expectStat("Ambientes Cadastrados", "2");
+      expectStat("Responsáveis Ativos", "2");
+      expectStat("Itens em Manutenção", "2");
+    });
+  });
+
+  it("renderiza atividades recentes baseadas no audit log", async () => {
+    mockFetch((url) => ({ status: 200, body: routeBody(url) }));
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Patrimônio "1234" cadastrado')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/29\/04\/2026/)).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://localhost:8000/api/audit-log?limit=5",
+    );
+  });
+
+  it("exibe erro ao falhar carregamento", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network"));
+
+    render(<Dashboard />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/erro ao carregar dados do dashboard/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("exibe mensagem quando nao existem atividades recentes", async () => {
+    mockFetch((url) => {
+      if (url.includes("/audit-log")) {
+        return { status: 200, body: { ...auditLog, data: [] } };
+      }
+
+      return { status: 200, body: routeBody(url) };
+    });
+
+    render(<Dashboard />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/nenhuma atividade recente encontrada/i)).toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## O que mudou
- Substituídos os dados mockados do Dashboard por chamadas reais à API.
- Cards agora exibem totais reais de patrimônios, ambientes, responsáveis ativos e itens em manutenção.
- Atividades recentes agora são carregadas a partir dos eventos reais de auditoria (`audit-log`).
- Adicionados estados de carregamento, erro e lista vazia.
- Criado teste unitário para o componente `Dashboard`.

## Por quê
- O Dashboard da página inicial ainda exibia números e atividades fixas no código, o que não refletia o estado real do sistema.
- A mudança garante que a visão geral acompanhe os dados cadastrados e os eventos reais gerados pela aplicação.

## Como testar
- Rodar os testes do frontend:

```bash
cd src/front
npm test -- --runInBand
```

- Rodar o lint:

```bash
cd src/front
npm run lint
```

- Executar o projeto e acessar `http://localhost:3000`.
- Conferir se os cards mudam conforme os dados retornados pela API.
- Conferir se as atividades recentes aparecem com base nos registros de auditoria.

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)

## Comentários técnicos (mínimo 3)
- [Risco] O cálculo de “Itens em Manutenção” depende do nome do estado conter “manutenção”, normalizando acentos para evitar falhas com variações como `Manutencao`.
- [Manutenção] A implementação segue o padrão atual do front, com `useEffect`, `useState`, `fetch` direto no componente e uso de `API_URL`.
- [Teste] O novo teste cobre carregamento dos cards, atividades recentes via audit log, erro na API e cenário sem atividades recentes.
- [Risco] A lista de atividades depende do endpoint `/audit-log?limit=5` retornar o formato paginado com a propriedade `data`.
- [Manutenção] As funções auxiliares de formatação e descrição dos logs ficaram isoladas no próprio componente para manter o escopo da alteração pequeno.